### PR TITLE
hybrid dp&sp for sft

### DIFF
--- a/Llama3-70B.sh
+++ b/Llama3-70B.sh
@@ -5,6 +5,7 @@ NGPUS=${NGPUS:-8}
 WORLD_SIZE=${WORLD_SIZE:-1}
 NUM_PROCESSES=$[${NGPUS}*$[WORLD_SIZE]]
 SEQ_LEN=${SEQ_LEN:-32768}
+SP_GROUP_SIZE=${SP_GROUP_SIZE:-1}
 BATCH_SIZE=${BATCH_SIZE:-1}
 export PYTORCH_CUDA_ALLOC_CONF='max_split_size_mb:1024' 
 export WANDB_DISABLED=true
@@ -29,6 +30,7 @@ src/train.py \
 --do_train \
 --finetuning_type full \
 --parallel_mode dist_flash_attn \
+--seq_parallel_size ${SP_GROUP_SIZE} \
 --deepspeed examples/deepspeed/ds_z3_offload_config.json \
 --dataset long_sft_128k \
 --template llama3 \

--- a/Llama3-70B.sh
+++ b/Llama3-70B.sh
@@ -39,7 +39,7 @@ src/train.py \
 --overwrite_cache \
 --preprocessing_num_workers 16 \
 --output_dir ./output/70B_32K_bs_1M_rope_1M_step_1000_lr_2e-5 \
---logging_steps 10 \
+--logging_steps 1 \
 --save_steps 500 \
 --plot_loss \
 --overwrite_output_dir \
@@ -53,7 +53,7 @@ src/train.py \
 --ddp_timeout 180000000 \
 --val_size 0.1 \
 --eval_strategy steps \
---eval_steps 2
+--eval_steps 1000
 
 # In the saved files, there are model-00001-of-00003.safetensors to model-00001-of-00003.safetensors. Somehow model.safetensors is unnecessary and should be removed.
 # rm output/7B_32K_bs_1M_rope_1M_step_1000_lr_2e-5/model.safetensors

--- a/Llama3-8B.sh
+++ b/Llama3-8B.sh
@@ -5,6 +5,7 @@ NGPUS=${NGPUS:-8}
 WORLD_SIZE=${WORLD_SIZE:-1}
 NUM_PROCESSES=$[${NGPUS}*$[WORLD_SIZE]]
 SEQ_LEN=${SEQ_LEN:-1024}
+SP_GROUP_SIZE=${SP_GROUP_SIZE:-1}
 BATCH_SIZE=${BATCH_SIZE:-1}
 export PYTORCH_CUDA_ALLOC_CONF='max_split_size_mb:1024' 
 export WANDB_DISABLED=true
@@ -30,6 +31,7 @@ src/train.py \
 --finetuning_type full \
 --lora_target all \
 --parallel_mode dist_flash_attn \
+--seq_parallel_size ${SP_GROUP_SIZE} \
 --deepspeed examples/deepspeed/ds_z3_offload_config.json \
 --dataset alpaca_en \
 --template llama3 \

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -99,8 +99,12 @@ class SeqParallelDataCollator(DataCollatorForSeq2Seq):
         input_ids = batch["input_ids"]
         attention_mask = batch["attention_mask"]
         labels = batch["labels"]
+        seq_rank = self.rank
+        seq_worlds_size = self.world_size
         if self.seq_parallel_size != -1:
             dp_rank = self.rank // self.seq_parallel_size
+            seq_rank = self.rank % self.seq_parallel_size
+            seq_worlds_size = self.seq_parallel_size
             bs = len(input_ids)
             data_group_size = self.world_size // self.seq_parallel_size
             group_bs = bs // data_group_size
@@ -112,8 +116,8 @@ class SeqParallelDataCollator(DataCollatorForSeq2Seq):
                                                 attention_mask=attention_mask,
                                                 position_ids=None,
                                                 labels=labels,
-                                                rank=self.rank,
-                                                world_size=self.world_size,
+                                                rank=seq_rank,
+                                                world_size=seq_worlds_size,
                                                 device=self.device)
         return batch
 
@@ -134,8 +138,12 @@ class SeqParallelDataCollatorForLanguageModeling(DataCollatorForLanguageModeling
         batch = super().__call__(examples)
         if self.seq_algo == "data_parallel":
             return batch
+        seq_rank = self.rank
+        seq_worlds_size = self.world_size
         if self.seq_parallel_size != -1:
             dp_rank = self.rank // self.seq_parallel_size
+            seq_rank = self.rank % self.seq_parallel_size
+            seq_worlds_size = self.seq_parallel_size
             bs = len(input_ids)
             data_group_size = self.world_size // self.seq_parallel_size
             group_bs = bs // data_group_size
@@ -150,7 +158,7 @@ class SeqParallelDataCollatorForLanguageModeling(DataCollatorForLanguageModeling
                                                 attention_mask=attention_mask,
                                                 position_ids=None,
                                                 labels=labels,
-                                                rank=self.rank,
-                                                world_size=self.world_size,
+                                                rank=seq_rank,
+                                                world_size=seq_worlds_size,
                                                 device=self.device)
         return batch

--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -86,10 +86,12 @@ class SeqParallelDataCollator(DataCollatorForSeq2Seq):
     r"""
     Data collator for sequence parallel in supervised finetune(sft) stage.
     """
-    seq_algo: str = "data_parallel"
+    seq_algo: str = "data_parallel",
+    seq_parallel_size: int = -1
     rank: int = 0
     world_size: int = 8
     device: Optional[Any] = None
+
     def __call__(self, features: Sequence[Dict[str, Any]], return_tensors=None) -> Dict[str, torch.Tensor]:
         batch = super().__call__(features, return_tensors)
         if self.seq_algo == "data_parallel":
@@ -97,13 +99,21 @@ class SeqParallelDataCollator(DataCollatorForSeq2Seq):
         input_ids = batch["input_ids"]
         attention_mask = batch["attention_mask"]
         labels = batch["labels"]
-        batch = prepare_seq_parallel_sft_inputs(self.seq_algo, 
-                                                input_ids=input_ids, 
-                                                attention_mask=attention_mask, 
-                                                position_ids=None, 
-                                                labels=labels, 
-                                                rank=self.rank, 
-                                                world_size=self.world_size, 
+        if self.seq_parallel_size != -1:
+            dp_rank = self.rank // self.seq_parallel_size
+            bs = len(input_ids)
+            data_group_size = self.world_size // self.seq_parallel_size
+            group_bs = bs // data_group_size
+            input_ids = input_ids[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+            attention_mask = attention_mask[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+            labels = labels[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+        batch = prepare_seq_parallel_sft_inputs(self.seq_algo,
+                                                input_ids=input_ids,
+                                                attention_mask=attention_mask,
+                                                position_ids=None,
+                                                labels=labels,
+                                                rank=self.rank,
+                                                world_size=self.world_size,
                                                 device=self.device)
         return batch
 
@@ -115,23 +125,32 @@ class SeqParallelDataCollatorForLanguageModeling(DataCollatorForLanguageModeling
     Reuse the sequence parallel distributing function for sft stage.
     """
     seq_algo: str = "data_parallel"
+    seq_parallel_size: int = -1
     rank: int = 0
     world_size: int = 8
     device: Optional[Any] = None
-    
+
     def __call__(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:
         batch = super().__call__(examples)
         if self.seq_algo == "data_parallel":
             return batch
+        if self.seq_parallel_size != -1:
+            dp_rank = self.rank // self.seq_parallel_size
+            bs = len(input_ids)
+            data_group_size = self.world_size // self.seq_parallel_size
+            group_bs = bs // data_group_size
+            input_ids = input_ids[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+            attention_mask = attention_mask[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+            labels = labels[dp_rank * group_bs: (dp_rank + 1) * group_bs]
         input_ids = batch["input_ids"]
         attention_mask = batch["attention_mask"]
         labels = batch["labels"]
-        batch = prepare_seq_parallel_sft_inputs(self.seq_algo, 
-                                                input_ids=input_ids, 
-                                                attention_mask=attention_mask, 
-                                                position_ids=None, 
-                                                labels=labels, 
-                                                rank=self.rank, 
-                                                world_size=self.world_size, 
+        batch = prepare_seq_parallel_sft_inputs(self.seq_algo,
+                                                input_ids=input_ids,
+                                                attention_mask=attention_mask,
+                                                position_ids=None,
+                                                labels=labels,
+                                                rank=self.rank,
+                                                world_size=self.world_size,
                                                 device=self.device)
         return batch

--- a/src/llamafactory/easy_context/__init__.py
+++ b/src/llamafactory/easy_context/__init__.py
@@ -64,7 +64,7 @@ def prepare_seq_parallel_sft_inputs(
         raise ValueError(f"Invalid seq_algo: {seq_algo}")
     
 def apply_seq_parallel_monkey_patch(
-    seq_algo, model
+    seq_algo, model,seq_parallel_size=None
 ):
     assert seq_algo in ["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
     assert model in ["llama", "mistral"], f"Invalid model: {model}"
@@ -75,7 +75,7 @@ def apply_seq_parallel_monkey_patch(
     elif seq_algo == "zigzag_ring_attn" and model == "mistral":
         apply_zigzag_ring_attn_monkey_patch_mistral()
     elif seq_algo == "dist_flash_attn" and model == "llama":
-        apply_dist_flash_attn_monkey_patch_llama()
+        apply_dist_flash_attn_monkey_patch_llama(seq_parallel_size=seq_parallel_size)
     elif seq_algo == "ulysses_attn" and model == "llama":
         apply_ulysses_attn_monkey_patch_llama()
     else:

--- a/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
@@ -65,7 +65,7 @@ def _initialize_sequence_parallel(sequence_parallel_size=None):
     world_size: int = torch.distributed.get_world_size()
     print(f"sequence_parallel_size is {sequence_parallel_size}, world_size is {world_size}")
 
-    if sequence_parallel_size is None:
+    if sequence_parallel_size is None or sequence_parallel_size == -1:
         sequence_parallel_size = world_size
     else:
         assert world_size % sequence_parallel_size == 0

--- a/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
@@ -39,7 +39,7 @@ _fwd_recv_volume = 0
 _bwd_send_volume = 0
 _bwd_recv_volume = 0
 
-def initialize_distributed():
+def initialize_distributed(sequence_parallel_size=None):
     if dist.is_initialized():
         if dist.get_rank() == 0:
             print(
@@ -55,12 +55,13 @@ def initialize_distributed():
         global_world_size = dist.get_world_size()
         torch.cuda.set_device(dist.get_rank() % local_world_size)
 
-    _initialize_sequence_parallel()
+    _initialize_sequence_parallel(sequence_parallel_size=sequence_parallel_size)
    # create_nccl_communicators()
 
 def _initialize_sequence_parallel(sequence_parallel_size=None):
     # Get world size and rank. Ensure some consistencies.
-    assert sequence_parallel_size is None, "Multiple sequence parallel group not implemented."
+    # assert sequence_parallel_size is None, "Multiple sequence parallel group not implemented."
+    print(f"sequence_parallel_size is {sequence_parallel_size}")
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
 

--- a/src/llamafactory/easy_context/dist_flash_attn/monkey_patch.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/monkey_patch.py
@@ -602,7 +602,7 @@ def forward(
     )
 
 
-def apply_dist_flash_attn_monkey_patch_llama():
-    initialize_distributed()
+def apply_dist_flash_attn_monkey_patch_llama(seq_parallel_size=None):
+    initialize_distributed(sequence_parallel_size=seq_parallel_size)
     transformers.models.llama.modeling_llama.LlamaModel.forward = forward
     transformers.models.llama.modeling_llama.LlamaDecoderLayer.forward = llama_layer_forward

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -316,6 +316,12 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         default="data_parallel",
         metadata={"help": "which sequence parallel mode to use."},
     )
+    seq_parallel_size: int = field(
+        default=-1,
+        metadata={
+            "help": "used for use seq_parallel and data_parallel simultaneously, -1 for all gpus parallels in sequence_length axis, n for n_gpus makes a sequence_parallel group"
+        }
+    )
 
     def __post_init__(self):
         def split_arg(arg):

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -192,7 +192,7 @@ class CustomSeqParallelTrainer(CustomSeq2SeqTrainer):
                 for b in range(bs):
                     normalizer=valid_label_cnt_all[b].item()
                     loss[b]=loss_fn(shift_logits[b], shift_labels[b])/normalizer
-                loss = loss.mean()*n_gpus
+                loss = loss.mean()*sp_size
 
         return (loss, outputs) if return_outputs else loss
 

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -278,7 +278,7 @@ class CustomSeqParallelTrainer(CustomSeq2SeqTrainer):
             self._eval_dataloader = eval_dataloader
 
         if hasattr(data_collator, "seq_algo") and data_collator.seq_algo != "data_parallel":
-            seq_parallel_size = self.args.seq_parallel_size
+            seq_parallel_size = self.finetuning_args.seq_parallel_size
             if seq_parallel_size != -1:
                 world_size = int(os.environ['WORLD_SIZE'])
                 assert seq_parallel_size != 0 and world_size % seq_parallel_size == 0, f"world_size: {world_size} should be devide by seq_parallel_size: {seq_parallel_size}"

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -183,8 +183,8 @@ class CustomSeqParallelTrainer(CustomSeq2SeqTrainer):
                 if sp_size == -1:
                     sp_size = n_gpus
                 dp_size = n_gpus // sp_size
-                dp_rank = self.accelerator.process_index // dp_size
-                valid_label_cnt_all =valid_label_cnt_gather[dp_rank * sp_size : (dp_rank+1) * sp_size].sum(0)
+                dp_rank = self.accelerator.process_index // sp_size
+                valid_label_cnt_all =valid_label_cnt_gather[dp_rank * sp_size : (dp_rank+1) * sp_size].sum(0).detach()
                 shift_logits = logits.contiguous()
                 shift_labels = labels.contiguous()
                 bs = len(shift_labels)

--- a/src/llamafactory/train/sft/workflow.py
+++ b/src/llamafactory/train/sft/workflow.py
@@ -37,7 +37,7 @@ def run_sft(
     tokenizer = tokenizer_module["tokenizer"]
     dataset = get_dataset(model_args, data_args, training_args, stage="sft", **tokenizer_module)
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train)
-    apply_seq_parallel_monkey_patch(finetuning_args.parallel_mode, "llama")
+    apply_seq_parallel_monkey_patch(finetuning_args.parallel_mode, "llama", seq_parallel_size=finetuning_args.seq_parallel_size)
 
     if training_args.predict_with_generate:
         tokenizer.padding_side = "left"  # use left-padding in generation
@@ -53,6 +53,7 @@ def run_sft(
         pad_to_multiple_of=data_args.cutoff_len if tokenizer.padding_side == "right" else None,
         label_pad_token_id=IGNORE_INDEX if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id,
         seq_algo=finetuning_args.parallel_mode,
+        seq_parallel_size=finetuning_args.seq_parallel_size,
         rank=torch.distributed.get_rank(),
         world_size=world_size,
         device=torch.device("cuda", local_rank)


### PR DESCRIPTION
增加dp和sp的混合并行模式，仅对dist_flash_attn这种序列并行生效，通过seq_parallel_size参数控制多少张卡为一个序列并行组，代码逻辑：    
总体逻辑： 先dp取dp_group的数据，再通过sp分发  
dp： 计算dp组数dp_size=world_size/sp_size, dataloader调整bs为原始bs的dp_size倍，对每个进程获取自己所在的dp_group, 取当前dp_group下的数据batch
sp: dist_flash_attn其实本来是按照分组序列并行写的，只不过细节处有一个bug：torch p2p算子中的rank需要去global_rank而不是group_rank，因为这个bug存在所以官方宣称分组序列并行未实现
以下为实验测试结果：    
4台机器，seq_len=32k, llama3-70b, 运行10个step:  
 实验组：seq_parallel_size=8  
```
{'loss': 3.9517, 'grad_norm': 128.84416372502568, 'learning_rate': 2e-05, 'epoch': 0.0}
{'loss': 4.6127, 'grad_norm': 499.06196862352283, 'learning_rate': 1.9396926207859085e-05, 'epoch': 0.01}
{'loss': 4.6737, 'grad_norm': 1161.1072395673284, 'learning_rate': 1.766044443118978e-05, 'epoch': 0.01}
{'loss': 2.0445, 'grad_norm': 44.22977359673547, 'learning_rate': 1.5000000000000002e-05, 'epoch': 0.01}
{'loss': 4.3886, 'grad_norm': 24.952257143551616, 'learning_rate': 1.1736481776669307e-05, 'epoch': 0.02}
{'loss': 3.3298, 'grad_norm': 59.61200218435648, 'learning_rate': 8.263518223330698e-06, 'epoch': 0.02}
{'loss': 2.1731, 'grad_norm': 16.610973706540637, 'learning_rate': 5.000000000000003e-06, 'epoch': 0.02}
{'loss': 5.3756, 'grad_norm': 41.93769798876979, 'learning_rate': 2.339555568810221e-06, 'epoch': 0.03}
{'loss': 3.8055, 'grad_norm': 15.164555774885692, 'learning_rate': 6.030737921409169e-07, 'epoch': 0.03}
{'loss': 4.3506, 'grad_norm': 48.691746141733745, 'learning_rate': 0.0, 'epoch': 0.04}
100%|██████████| 10/10 [15:49<00:00, 92.67s/it][INFO|trainer.py:2328] 2024-07-12 08:09:26,351 >> 

Training completed. Do not forget to share your model on huggingface.co/models =)


{'train_runtime': 949.041, 'train_samples_per_second': 1.349, 'train_steps_per_second': 0.011, 'train_loss': 3.8705761432647705, 'epoch': 0.04}
100%|██████████| 10/10 [15:49<00:00, 94.90s/it]
```
对照组： seq_parallel_size=-1 (默认，即所有gpu为一个序列并行组)  ：  
```
{'loss': 3.95, 'grad_norm': 119.14682403592798, 'learning_rate': 2e-05, 'epoch': 0.0}
{'loss': 4.6129, 'grad_norm': 225.7792762655119, 'learning_rate': 1.9396926207859085e-05, 'epoch': 0.01}
{'loss': 4.598, 'grad_norm': 141.44144227641831, 'learning_rate': 1.766044443118978e-05, 'epoch': 0.01}
{'loss': 2.0055, 'grad_norm': 42.79770850512974, 'learning_rate': 1.5000000000000002e-05, 'epoch': 0.01}
{'loss': 4.4408, 'grad_norm': 30.856081857051624, 'learning_rate': 1.1736481776669307e-05, 'epoch': 0.02}
{'loss': 3.3489, 'grad_norm': 60.51319017046075, 'learning_rate': 8.263518223330698e-06, 'epoch': 0.02}
{'loss': 2.1637, 'grad_norm': 29.131536574985663, 'learning_rate': 5.000000000000003e-06, 'epoch': 0.02}
{'loss': 5.3836, 'grad_norm': 35.03628293297368, 'learning_rate': 2.339555568810221e-06, 'epoch': 0.03}
{'loss': 3.7249, 'grad_norm': 88.04944989881702, 'learning_rate': 6.030737921409169e-07, 'epoch': 0.03}
{'loss': 4.5497, 'grad_norm': 309.9493492006651, 'learning_rate': 0.0, 'epoch': 0.04}
100%|██████████| 10/10 [39:02<00:00, 232.60s/it][INFO|trainer.py:2328] 2024-07-12 08:42:05,770 >> 

Training completed. Do not forget to share your model on huggingface.co/models =)


{'train_runtime': 2342.245, 'train_samples_per_second': 2.186, 'train_steps_per_second': 0.004, 'train_loss': 3.877790832519531, 'epoch': 0.04}
100%|██████████| 10/10 [39:02<00:00, 234.22s/it]
```
