### PR TITLE
add feat: add activate offload

### DIFF
--- a/src/llamafactory/easy_context/__init__.py
+++ b/src/llamafactory/easy_context/__init__.py
@@ -64,7 +64,7 @@ def prepare_seq_parallel_sft_inputs(
         raise ValueError(f"Invalid seq_algo: {seq_algo}")
     
 def apply_seq_parallel_monkey_patch(
-    seq_algo, model, sp_size=None
+    seq_algo, model, sp_size=None, enable_offload=False, offload_percent=0.
 ):
     assert seq_algo in ["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
     assert model in ["llama", "mistral"], f"Invalid model: {model}"
@@ -75,7 +75,7 @@ def apply_seq_parallel_monkey_patch(
     elif seq_algo == "zigzag_ring_attn" and model == "mistral":
         apply_zigzag_ring_attn_monkey_patch_mistral()
     elif seq_algo == "dist_flash_attn" and model == "llama":
-        apply_dist_flash_attn_monkey_patch_llama(sp_size=sp_size)
+        apply_dist_flash_attn_monkey_patch_llama(sp_size=sp_size, enable_offload=enable_offload, offload_percent=offload_percent)
     elif seq_algo == "ulysses_attn" and model == "llama":
         apply_ulysses_attn_monkey_patch_llama()
     else:

--- a/src/llamafactory/easy_context/dist_flash_attn/offload_buffer.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/offload_buffer.py
@@ -1,0 +1,92 @@
+import pycuda
+import pycuda.driver as drv
+import pycuda.autoinit
+import numpy as np
+
+class OffloadBuffer:
+    
+    def __init__(self, enable_offload, offload_percent):
+        self.enable_offload = enable_offload
+        self.offload_percent = offload_percent
+        self.allocated = False
+
+    def allocate(self, num_layers, shape):
+        if self.allocated:
+            return
+        self.layer_num = num_layers
+        self.gpu_layer_num = int(num_layers * self.offload_percent)
+        self.cpu_layer_num = num_layers - self.gpu_layer_num
+        self.gpu_buffer = [None for _ in range(self.gpu_layer_num)]
+        self.cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape, dtype=np.float16)
+        bs, num_heads, seq_len, emb_size = shape
+        shape_h = [bs, seq_len, num_heads * emb_size]
+        shape_a = [bs, seq_len]
+        self.hidden_state_gpu_buffer = [None for _ in range(self.gpu_layer_num)]
+        self.hidden_state_cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape_h, dtype=np.float16)
+        self.position_id_gpu_buffer = [None for _ in range(self.gpu_layer_num)]
+        self.position_id_cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape_a, dtype=np.float16)
+        self.d2h_stream = drv.Stream()
+        self.h2d_streams = [drv.Stream() for _ in range(self.gpu_layer_num)]
+        self.allocated = True
+
+    def save_flash_attn_out(self, layer_idx, out):
+        if layer_idx < 0:
+            layer_idx = self.layer_num + layer_idx
+        if layer_idx < self.cpu_layer_num:
+            drv.memcpy_dtoh_async(self.cpu_buffer[layer_idx], out.data_ptr(), self.d2h_stream)
+        else:
+            idx = layer_idx - self.cpu_layer_num
+            self.gpu_buffer[idx] = out
+            
+    def save_hidden_states(self, layer_idx, *hs):
+        if layer_idx < 0:
+            layer_idx = self.layer_num + layer_idx
+        hidden_state = hs[0]
+        position_id = hs[1]
+        if layer_idx < self.cpu_layer_num:
+            drv.memcpy_dtoh_async(self.hidden_state_cpu_buffer[layer_idx], hidden_state.data_ptr(), self.d2h_stream)
+            drv.memcpy_dtoh_async(self.position_id_cpu_buffer[layer_idx], position_id.data_ptr(), self.d2h_stream)
+        else:
+            idx = layer_idx - self.cpu_layer_num
+            self.hidden_state_gpu_buffer[idx] = hidden_state
+            self.position_id_gpu_buffer[idx] = position_id
+
+    def get_flash_attn_out(self, layer_idx):
+        if layer_idx < 0:
+            layer_idx = self.layer_num + layer_idx
+        if layer_idx >= self.cpu_layer_num:
+            return self.gpu_buffer[layer_idx - self.cpu_layer_num]
+        idx = self.gpu_layer_num -1 - (self.cpu_layer_num - 1 - layer_idx) % self.gpu_layer_num
+        self.h2d_streams[idx].synchronize()
+        return self.gpu_buffer[idx]
+    
+    def get_hidden_states(self, layer_idx):
+        if layer_idx < 0:
+            layer_idx = self.layer_num + layer_idx
+        if layer_idx >= self.cpu_layer_num:
+            return self.hidden_state_gpu_buffer[layer_idx - self.cpu_layer_num], self.position_id_gpu_buffer[layer_idx - self.cpu_layer_num]
+        idx = self.gpu_layer_num -1 - (self.cpu_layer_num - 1 - layer_idx) % self.gpu_layer_num
+        self.h2d_streams[idx].synchronize()
+        return self.hidden_state_gpu_buffer[idx], self.position_id_gpu_buffer[idx]
+
+    def free_layer_gpu_buffer(self, layer_idx):
+        if layer_idx < 0:
+            layer_idx = self.layer_num + layer_idx
+        if layer_idx == self.layer_num - 1:
+            self.d2h_stream.synchronize()
+        cpu_layer_idx = layer_idx - self.gpu_layer_num
+        if layer_idx >= self.cpu_layer_num:
+            idx = layer_idx - self.cpu_layer_num
+        else:
+            idx = self.gpu_layer_num -1 - (self.cpu_layer_num - 1 - layer_idx) % self.gpu_layer_num
+        self.gpu_buffer[idx].grad = None
+        if cpu_layer_idx < 0:
+            self.gpu_buffer[idx] = None
+            self.hidden_state_gpu_buffer[idx] = None
+            self.position_id_gpu_buffer[idx] = None
+            return
+        drv.memcpy_htod_async(self.gpu_buffer[idx].data_ptr(), self.cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
+        drv.memcpy_htod_async(self.hidden_state_gpu_buffer[idx].data_ptr(), self.hidden_state_cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
+        drv.memcpy_htod_async(self.position_id_gpu_buffer[idx].data_ptr(), self.position_id_cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
+        
+offload_buffer = None

--- a/src/llamafactory/easy_context/dist_flash_attn/offload_buffer.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/offload_buffer.py
@@ -1,7 +1,6 @@
-import pycuda
-import pycuda.driver as drv
-import pycuda.autoinit
-import numpy as np
+import cuda
+import cuda.cudart
+import torch
 
 class OffloadBuffer:
     
@@ -14,26 +13,29 @@ class OffloadBuffer:
         if self.allocated:
             return
         self.layer_num = num_layers
-        self.gpu_layer_num = int(num_layers * self.offload_percent)
-        self.cpu_layer_num = num_layers - self.gpu_layer_num
+        self.cpu_layer_num = int(num_layers * self.offload_percent)
+        self.gpu_layer_num = num_layers - self.cpu_layer_num
         self.gpu_buffer = [None for _ in range(self.gpu_layer_num)]
-        self.cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape, dtype=np.float16)
+        self.cpu_buffer = [torch.empty([self.cpu_layer_num] + shape, dtype=torch.bfloat16) for _ in range(self.cpu_layer_num)]
         bs, num_heads, seq_len, emb_size = shape
         shape_h = [bs, seq_len, num_heads * emb_size]
         shape_a = [bs, seq_len]
         self.hidden_state_gpu_buffer = [None for _ in range(self.gpu_layer_num)]
-        self.hidden_state_cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape_h, dtype=np.float16)
+        self.hidden_state_cpu_buffer = [torch.empty([self.cpu_layer_num] + shape_h, dtype=torch.bfloat16) for _ in range(self.cpu_layer_num)]
         self.position_id_gpu_buffer = [None for _ in range(self.gpu_layer_num)]
-        self.position_id_cpu_buffer = drv.pagelocked_empty([self.cpu_layer_num] + shape_a, dtype=np.float16)
-        self.d2h_stream = drv.Stream()
-        self.h2d_streams = [drv.Stream() for _ in range(self.gpu_layer_num)]
+        self.position_id_cpu_buffer = [torch.empty([self.cpu_layer_num] + shape_a, dtype=torch.bfloat16) for _ in range(self.cpu_layer_num)]
+        _, self.d2h_stream = cuda.cudart.cudaStreamCreate()
+        self.h2d_streams = []
+        for i in range(self.gpu_layer_num):
+            _, h2d_stream = cuda.cudart.cudaStreamCreate()
+            self.h2d_streams.append(h2d_stream)
         self.allocated = True
 
     def save_flash_attn_out(self, layer_idx, out):
         if layer_idx < 0:
             layer_idx = self.layer_num + layer_idx
         if layer_idx < self.cpu_layer_num:
-            drv.memcpy_dtoh_async(self.cpu_buffer[layer_idx], out.data_ptr(), self.d2h_stream)
+            _ = cuda.cudart.cudaMemcpyAsync(self.cpu_buffer[layer_idx].data_ptr(), out.data_ptr(), out.nelement() * out.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost, self.d2h_stream)
         else:
             idx = layer_idx - self.cpu_layer_num
             self.gpu_buffer[idx] = out
@@ -44,8 +46,8 @@ class OffloadBuffer:
         hidden_state = hs[0]
         position_id = hs[1]
         if layer_idx < self.cpu_layer_num:
-            drv.memcpy_dtoh_async(self.hidden_state_cpu_buffer[layer_idx], hidden_state.data_ptr(), self.d2h_stream)
-            drv.memcpy_dtoh_async(self.position_id_cpu_buffer[layer_idx], position_id.data_ptr(), self.d2h_stream)
+            _ = cuda.cudart.cudaMemcpyAsync(self.hidden_state_cpu_buffer[layer_idx].data_ptr(), hidden_state.data_ptr(), hidden_state.nelement() * hidden_state.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost, self.d2h_stream)
+            _ = cuda.cudart.cudaMemcpyAsync(self.position_id_cpu_buffer[layer_idx].data_ptr(), position_id.data_ptr(), position_id.nelement() * position_id.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyDeviceToHost, self.d2h_stream)
         else:
             idx = layer_idx - self.cpu_layer_num
             self.hidden_state_gpu_buffer[idx] = hidden_state
@@ -57,7 +59,7 @@ class OffloadBuffer:
         if layer_idx >= self.cpu_layer_num:
             return self.gpu_buffer[layer_idx - self.cpu_layer_num]
         idx = self.gpu_layer_num -1 - (self.cpu_layer_num - 1 - layer_idx) % self.gpu_layer_num
-        self.h2d_streams[idx].synchronize()
+        _ = cuda.cudart.cudaStreamSynchronize(self.h2d_streams[idx])
         return self.gpu_buffer[idx]
     
     def get_hidden_states(self, layer_idx):
@@ -66,14 +68,14 @@ class OffloadBuffer:
         if layer_idx >= self.cpu_layer_num:
             return self.hidden_state_gpu_buffer[layer_idx - self.cpu_layer_num], self.position_id_gpu_buffer[layer_idx - self.cpu_layer_num]
         idx = self.gpu_layer_num -1 - (self.cpu_layer_num - 1 - layer_idx) % self.gpu_layer_num
-        self.h2d_streams[idx].synchronize()
+        _ = cuda.cudart.cudaStreamSynchronize(self.h2d_streams[idx])
         return self.hidden_state_gpu_buffer[idx], self.position_id_gpu_buffer[idx]
 
     def free_layer_gpu_buffer(self, layer_idx):
         if layer_idx < 0:
             layer_idx = self.layer_num + layer_idx
         if layer_idx == self.layer_num - 1:
-            self.d2h_stream.synchronize()
+            _ = cuda.cudart.cudaStreamSynchronize(self.d2h_stream)
         cpu_layer_idx = layer_idx - self.gpu_layer_num
         if layer_idx >= self.cpu_layer_num:
             idx = layer_idx - self.cpu_layer_num
@@ -85,8 +87,19 @@ class OffloadBuffer:
             self.hidden_state_gpu_buffer[idx] = None
             self.position_id_gpu_buffer[idx] = None
             return
-        drv.memcpy_htod_async(self.gpu_buffer[idx].data_ptr(), self.cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
-        drv.memcpy_htod_async(self.hidden_state_gpu_buffer[idx].data_ptr(), self.hidden_state_cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
-        drv.memcpy_htod_async(self.position_id_gpu_buffer[idx].data_ptr(), self.position_id_cpu_buffer[cpu_layer_idx], self.h2d_streams[idx])
+        cb = self.cpu_buffer[cpu_layer_idx]
+        hcb = self.hidden_state_cpu_buffer[cpu_layer_idx]
+        pcb = self.position_id_cpu_buffer[cpu_layer_idx]
+        gb = self.gpu_buffer[idx]
+        hgb = self.hidden_state_gpu_buffer[idx]
+        pgb = self.position_id_gpu_buffer[idx]
+        _ = cuda.cudart.cudaMemcpyAsync(gb.data_ptr(), cb.data_ptr(), gb.nelement() * gb.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, self.h2d_streams[idx])
+        _ = cuda.cudart.cudaMemcpyAsync(hgb.data_ptr(), hcb.data_ptr(), hgb.nelement() * hgb.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, self.h2d_streams[idx])
+        _ = cuda.cudart.cudaMemcpyAsync(pgb.data_ptr(), pcb.data_ptr(), pgb.nelement() * pgb.element_size(), cuda.cudart.cudaMemcpyKind.cudaMemcpyHostToDevice, self.h2d_streams[idx])
+        
+    def __del__(self):
+        cuda.cudart.cudaStreamDestroy(self.d2h_stream)
+        for i in range(self.gpu_layer_num):
+            cuda.cudart.cudaStreamDestroy(self.h2d_streams[i])
         
 offload_buffer = None

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -320,7 +320,15 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         default=-1,
         metadata={
             "help": "allow using seq_parallel and data_parallel simultaneously, -1 for all gpus parallels in sequence_length axis, n for n_gpus makes a sequence_parallel group"
-        }
+        },
+    )
+    sp_enable_offload: bool = field(
+        default=False,
+        metadata={"help": "whether enable offload activation to cpu for dist_flash_attn"},
+    )
+    sp_offload_percent: float = field(
+        default=0.0,
+        metadata={"help": "0 for remain all activation memory in gpu, 1 for offload all activation memory in cpu"}
     )
 
     def __post_init__(self):

--- a/src/llamafactory/train/sft/trainer.py
+++ b/src/llamafactory/train/sft/trainer.py
@@ -165,11 +165,6 @@ class CustomSeqParallelTrainer(CustomSeq2SeqTrainer):
             else:
                 loss = self.label_smoother(outputs, labels)
         else:
-            if isinstance(outputs, dict) and "loss" not in outputs:
-                raise ValueError(
-                    "The model did not return a loss from the inputs, only the following keys: "
-                    f"{','.join(outputs.keys())}. For reference, the inputs it received are {','.join(inputs.keys())}."
-                )
             # We don't use .loss here since the model may return tuples instead of ModelOutput.
             if self.finetuning_args.parallel_mode== "data_parallel":
                 loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]

--- a/tianqing_examples/Llama3-70B-sp-offload.sh
+++ b/tianqing_examples/Llama3-70B-sp-offload.sh
@@ -6,6 +6,7 @@ WORLD_SIZE=${WORLD_SIZE:-1}
 NUM_PROCESSES=$[${NGPUS}*$[WORLD_SIZE]]
 SEQ_LEN=${SEQ_LEN:-32768}
 SP_SIZE=${SP_SIZE:-1}
+SP_OFFLOAD_PERCENT=${SP_OFFLOAD_PERCENT:-0.8}
 BATCH_SIZE=${BATCH_SIZE:-1}
 export PYTORCH_CUDA_ALLOC_CONF='max_split_size_mb:1024' 
 export WANDB_DISABLED=true
@@ -32,6 +33,8 @@ src/train.py \
 --finetuning_type full \
 --parallel_mode dist_flash_attn \
 --sp_size ${SP_SIZE} \
+--sp_enable_offload \
+--sp_offload_percent ${SP_OFFLOAD_PERCENT} \
 --deepspeed examples/deepspeed/ds_z3_offload_config.json \
 --dataset long_sft_32k \
 --template llama3 \

--- a/tianqing_examples/Llama3-70B.sh
+++ b/tianqing_examples/Llama3-70B.sh
@@ -33,7 +33,7 @@ src/train.py \
 --parallel_mode dist_flash_attn \
 --sp_size ${SP_SIZE} \
 --deepspeed examples/deepspeed/ds_z3_offload_config.json \
---dataset long_sft_128k \
+--dataset long_sft_32k \
 --template llama3 \
 --cutoff_len ${SEQ_LEN} \
 --max_steps 10 \

--- a/tianqing_examples/Llama3-70B.sh
+++ b/tianqing_examples/Llama3-70B.sh
@@ -6,6 +6,7 @@ WORLD_SIZE=${WORLD_SIZE:-1}
 NUM_PROCESSES=$[${NGPUS}*$[WORLD_SIZE]]
 SEQ_LEN=${SEQ_LEN:-32768}
 SP_SIZE=${SP_SIZE:-1}
+SP_OFFLOAD_PERCENT=${SP_OFFLOAD_PERCENT:-0.8}
 BATCH_SIZE=${BATCH_SIZE:-1}
 export PYTORCH_CUDA_ALLOC_CONF='max_split_size_mb:1024' 
 export WANDB_DISABLED=true
@@ -32,6 +33,8 @@ src/train.py \
 --finetuning_type full \
 --parallel_mode dist_flash_attn \
 --sp_size ${SP_SIZE} \
+--sp_enable_offload \
+--sp_offload_percent ${SP_OFFLOAD_PERCENT} \
 --deepspeed examples/deepspeed/ds_z3_offload_config.json \
 --dataset long_sft_32k \
 --template llama3 \


### PR DESCRIPTION
* 增加新feature: activation_offload

该feature在forward过程中的前n层offload activation到cpu, 在backward过程加载对应层的activation到gpu，以此减少activation的显存占用
该feature仅对dist_flash_attn序列并行方式生效

* 使用方式：

在脚本中通过加入参数--sp_enable_offload激活该功能，通过参数--sp_offload_percent控制offload的比例（假如网络有N层，则卸载N*sp_offload_percent层的激活值到CPU），使用示例见tianqing_examples/Llama3-70B-sp-offload.sh

* 测试：
测试模型为Llama3-8B, seq_len=32k, offload_percent=80%
1. baseline
```
{'loss': 4.4243, 'grad_norm': 285.22976487846233, 'learning_rate': 2e-05, 'epoch': 0.0}                                                                                                                                                                                                                                              
{'loss': 1.1561, 'grad_norm': 184.1724852718975, 'learning_rate': 1.9396926207859085e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 4.0729, 'grad_norm': 158.56068404487678, 'learning_rate': 1.766044443118978e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 3.1879, 'grad_norm': 612.0534468609791, 'learning_rate': 1.5000000000000002e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 5.0777, 'grad_norm': 178.04634381032773, 'learning_rate': 1.1736481776669307e-05, 'epoch': 0.0}                                                                                                                                                                                                                             
{'loss': 2.9093, 'grad_norm': 209.4633676756293, 'learning_rate': 8.263518223330698e-06, 'epoch': 0.01}                                                                                                                                                                                                                              
{'loss': 2.1056, 'grad_norm': 192.2155174830521, 'learning_rate': 5.000000000000003e-06, 'epoch': 0.01}                                                                                                                                                                                                                              
{'loss': 5.3273, 'grad_norm': 547.8051826968687, 'learning_rate': 2.339555568810221e-06, 'epoch': 0.01}                                                                                                                                                                                                                              
{'loss': 5.0292, 'grad_norm': 202.3895975664728, 'learning_rate': 6.030737921409169e-07, 'epoch': 0.01}                                                                                                                                                                                                                              
{'loss': 3.7768, 'grad_norm': 59.10557839709398, 'learning_rate': 0.0, 'epoch': 0.01}                                                                                                                                                                                                                                                
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [03:10<00:00, 17.26s/it]
```

2. offload
```
{'loss': 4.4243, 'grad_norm': 291.5046518365578, 'learning_rate': 2e-05, 'epoch': 0.0}                                                                                                                                                                                                                                               
{'loss': 1.1561, 'grad_norm': 185.0571769029759, 'learning_rate': 1.9396926207859085e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 4.0752, 'grad_norm': 171.31181858742605, 'learning_rate': 1.766044443118978e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 3.2764, 'grad_norm': 449.3029084397367, 'learning_rate': 1.5000000000000002e-05, 'epoch': 0.0}                                                                                                                                                                                                                              
{'loss': 5.0709, 'grad_norm': 218.45454744432428, 'learning_rate': 1.1736481776669307e-05, 'epoch': 0.0}                                                                                                                                                                                                                             
{'loss': 2.895, 'grad_norm': 121.66447417297486, 'learning_rate': 8.263518223330698e-06, 'epoch': 0.01}                                                                                                                                                                                                                              
{'loss': 2.205, 'grad_norm': 275.4284664330184, 'learning_rate': 5.000000000000003e-06, 'epoch': 0.01}                                                                                                                                                                                                                               
{'loss': 5.3962, 'grad_norm': 410.16101633697303, 'learning_rate': 2.339555568810221e-06, 'epoch': 0.01}                                                                                                                                                                                                                             
{'loss': 5.2585, 'grad_norm': 228.90608403497814, 'learning_rate': 6.030737921409169e-07, 'epoch': 0.01}                                                                                                                                                                                                                             
{'loss': 4.2046, 'grad_norm': 277.9298577668743, 'learning_rate': 0.0, 'epoch': 0.01}                                                                                                                                                                                                                                                
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [03:22<00:00, 18.03s/it]
```