### PR TITLE
add zigzag varlen and update transformers to 4.47.0

### DIFF
--- a/src/llamafactory/data/collator.py
+++ b/src/llamafactory/data/collator.py
@@ -2,9 +2,14 @@ from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
 import torch
-from transformers import DataCollatorForSeq2Seq, DataCollatorForLanguageModeling
+from transformers import DataCollatorForSeq2Seq, DataCollatorForLanguageModeling, default_data_collator, DataCollatorWithFlattening
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from typing import Any, Callable, Dict, List, NewType, Optional, Tuple, Union
 from llamafactory.easy_context import prepare_seq_parallel_sft_inputs
+
+import os
+import torch.nn.functional as F
+from torch import distributed as dist
 
 @dataclass
 class PairwiseDataCollatorWithPadding(DataCollatorForSeq2Seq):
@@ -161,4 +166,95 @@ class SeqParallelDataCollatorForLanguageModeling(DataCollatorForLanguageModeling
                                                 rank=sp_rank,
                                                 world_size=world_size,
                                                 device=self.device)
+        return batch
+
+
+@dataclass
+class SeqParallelDataCollatorWithFlattening(DataCollatorWithFlattening):
+    """
+    Data collator used for padding free approach. Does the following:
+
+    - concatate the entire mini batch into single long sequence [1, total_tokens]
+    - uses `separator_id` to separate sequences within the concatenated `labels`, default value is -100
+    - no padding will be added, returns `input_ids`, `labels` and `position_ids`
+    """
+    tokenizer: PreTrainedTokenizerBase = None
+    seq_algo: str = "data_parallel"
+    sp_size: int = -1
+    rank: int = 0
+    world_size: int = 8
+    device: Optional[Any] = None
+    return_position_ids: bool = True
+    separator_id: int = -100
+
+
+
+    def __call__(self, features, return_tensors=None, separator_id=None):
+        assert self.seq_algo in ["data_parallel", "zigzag_ring_attn_varlen"], "SeqParallelDataCollatorWithFlattening only supports seq_algo of data_parallel or zigzag_ring_attn_varlen"
+        assert self.return_position_ids, "return_position_ids should be True"
+
+        if self.seq_algo == "data_parallel":
+            return super().__call__(features, return_tensors, separator_id)
+
+        if return_tensors is None:
+            return_tensors = self.return_tensors
+        if separator_id is None:
+            separator_id = self.separator_id
+        assert self.tokenizer.pad_token_id, "pad_token_id is necessary if you are using zigzag_ring_attn_varlen"
+        pad_token_id = self.tokenizer.pad_token_id
+
+        is_labels_provided = "labels" in features[0]
+        ret = {"input_ids": [], "labels": []}
+        seqlens_in_batch = []
+        pad_to_multiple_of = self.sp_size*2 if self.sp_size != 1 else self.world_size*2
+
+        world_size = self.world_size
+        sp_rank = self.rank
+        if self.sp_size != -1:
+            dp_rank = self.rank // self.sp_size
+            sp_rank = self.rank % self.sp_size
+            world_size = self.sp_size
+            bs = len(features)
+            dp_size = self.world_size // self.sp_size
+            group_bs = bs // dp_size
+            features = features[dp_rank * group_bs: (dp_rank + 1) * group_bs]
+
+        if self.return_position_ids:
+            ret.update({"position_ids": []})
+
+        for idx in range(0, len(features)):
+            token_num = len(features[idx]["input_ids"])
+            pad_num = ((token_num // pad_to_multiple_of) + 1) * pad_to_multiple_of - token_num
+            features[idx]["input_ids"] += pad_num * [pad_token_id]
+            features[idx]["labels"] += pad_num * [separator_id]
+            ret["input_ids"] += features[idx]["input_ids"]
+            seqlens_in_batch.append(len(features[idx]["input_ids"]))
+            if is_labels_provided:
+                ret["labels"] += [separator_id] + features[idx]["labels"][1:]
+            else:
+                ret["labels"] += [separator_id] + features[idx]["input_ids"][1:]
+            if self.return_position_ids:
+                ret["position_ids"] += list(range(len(features[idx]["input_ids"])))
+
+        seqlens_in_batch = torch.tensor(seqlens_in_batch, dtype=torch.int32, device=self.device)
+        cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
+        max_seqlen = seqlens_in_batch.max().item()
+        local_cu_seqlens_tensor = cu_seqlens // world_size
+        local_max_seqlen = max_seqlen // world_size
+        batch = default_data_collator([ret], return_tensors)
+        input_ids = batch["input_ids"]
+        labels = batch["labels"]
+        position_ids = batch["position_ids"]
+        batch = prepare_seq_parallel_sft_inputs(self.seq_algo,
+                                                input_ids=input_ids,
+                                                attention_mask=None,
+                                                position_ids=position_ids,
+                                                labels=labels,
+                                                rank=sp_rank,
+                                                world_size=world_size,
+                                                device=self.device,
+                                                cu_seqlens=cu_seqlens,
+                                                cu_seq_lens_q=local_cu_seqlens_tensor,
+                                                max_length_q=local_max_seqlen
+                                                )
         return batch

--- a/src/llamafactory/data/template.py
+++ b/src/llamafactory/data/template.py
@@ -378,7 +378,8 @@ def get_template_and_fix_tokenizer(
             logger.warning("New tokens have been added, make sure `resize_vocab` is True.")
 
     try:
-        tokenizer.chat_template = _get_jinja_template(template, tokenizer)
+        chat_template = _get_jinja_template(template, tokenizer)
+        tokenizer.pad_token = tokenizer.eos_token
     except ValueError:
         logger.info("Cannot add this chat template to tokenizer.")
 

--- a/src/llamafactory/easy_context/__init__.py
+++ b/src/llamafactory/easy_context/__init__.py
@@ -1,12 +1,16 @@
 from .dist_flash_attn.prepare_input import prepare_dist_flash_attn_inputs, prepare_dist_flash_attn_sft_inputs
 from .dist_flash_attn.monkey_patch import apply_dist_flash_attn_monkey_patch_llama
-from .zigzag_ring_attn.prepare_inputs import prepare_zigzag_ring_attn_inputs, prepare_zigzag_ring_attn_sft_inputs
-from .zigzag_ring_attn.monkey_patch import apply_zigzag_ring_attn_monkey_patch_llama    
+from .zigzag_ring_attn.prepare_inputs import prepare_zigzag_ring_attn_inputs, prepare_zigzag_ring_attn_sft_inputs, prepare_zigzag_ring_attn_varlen_sft_inputs
+from .zigzag_ring_attn.monkey_patch import apply_zigzag_ring_attn_monkey_patch_llama, apply_zigzag_ring_attn_varlen_monkey_patch_llama
 from .unsloth_offloaded_gradient_checkpoint.monkey_patch import apply_unsloth_offloaded_gradient_checkpoint_monkey_patch
 from .ulysses_attn.prepare_inputs import prepare_ulysses_attn_inputs, prepare_ulysses_attn_sft_inputs
 from .ulysses_attn.monkey_patch import apply_ulysses_attn_monkey_patch_llama 
 import torch
 import torch.nn.functional as F
+import transformers
+from transformers.models.llama.modeling_llama import Optional, Union, Cache, List, Unpack, KwargsForCausalLM, Tuple, CausalLMOutputWithPast, FlashAttentionKwargs, BaseModelOutputWithPast, logging, DynamicCache
+
+logger = logging.get_logger(__name__)
 
 def prepare_seq_parallel_inputs(
     seq_algo, input_ids, position_ids, target_ids, rank, world_size, device
@@ -33,7 +37,7 @@ def prepare_seq_parallel_inputs(
         raise ValueError(f"Invalid seq_algo: {seq_algo}")
     
 def prepare_seq_parallel_sft_inputs(
-    seq_algo, input_ids, attention_mask, position_ids, labels, rank, world_size, device
+    seq_algo, input_ids, attention_mask, position_ids, labels, rank, world_size, device, **kwargs
 ):
     if attention_mask is not None and position_ids is None:
         # create position_ids on the fly for batch generation
@@ -43,6 +47,10 @@ def prepare_seq_parallel_sft_inputs(
     if seq_algo == "zigzag_ring_attn":
         return prepare_zigzag_ring_attn_sft_inputs(
             input_ids, attention_mask, position_ids, shift_labels, rank, world_size, device
+        )
+    elif seq_algo == "zigzag_ring_attn_varlen":
+        return prepare_zigzag_ring_attn_varlen_sft_inputs(
+            input_ids, attention_mask, position_ids, shift_labels, rank, world_size, device, **kwargs
         )
     elif seq_algo == "dist_flash_attn":
         return prepare_dist_flash_attn_sft_inputs(
@@ -62,15 +70,211 @@ def prepare_seq_parallel_sft_inputs(
     else:
         raise ValueError(f"Invalid seq_algo: {seq_algo}")
     
+def model_forward(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
+) -> Union[Tuple, BaseModelOutputWithPast]:
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    use_cache = use_cache if use_cache is not None else self.config.use_cache
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    if (input_ids is None) ^ (inputs_embeds is not None):
+        raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+    if self.gradient_checkpointing and self.training and use_cache:
+        logger.warning_once(
+            "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
+        )
+        use_cache = False
+
+    if inputs_embeds is None:
+        inputs_embeds = self.embed_tokens(input_ids)
+
+    # kept for BC (non `Cache` `past_key_values` inputs)
+    return_legacy_cache = False
+    if use_cache and not isinstance(past_key_values, Cache):
+        return_legacy_cache = True
+        if past_key_values is None:
+            past_key_values = DynamicCache()
+        else:
+            past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            logger.warning_once(
+                "We detected that you are passing `past_key_values` as a tuple of tuples. This is deprecated and "
+                "will be removed in v4.47. Please convert your cache or use an appropriate `Cache` class "
+                "(https://huggingface.co/docs/transformers/kv_cache#legacy-cache-format)"
+            )
+
+    if cache_position is None:
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        cache_position = torch.arange(
+            past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+        )
+    if position_ids is None:
+        position_ids = cache_position.unsqueeze(0)
+
+    causal_mask = self._update_causal_mask(
+        attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
+    )
+    hidden_states = inputs_embeds
+
+    # create position embeddings to be shared across the decoder layers
+    position_embeddings = self.rotary_emb(hidden_states, position_ids)
+    position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+    # decoder layers
+    all_hidden_states = () if output_hidden_states else None
+    all_self_attns = () if output_attentions else None
+    next_decoder_cache = None
+
+    for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if self.gradient_checkpointing and self.training:
+            layer_outputs = self._gradient_checkpointing_func(
+                decoder_layer.__call__,
+                hidden_states,
+                causal_mask,
+                position_ids,
+                past_key_values,
+                output_attentions,
+                use_cache,
+                cache_position,
+                position_embeddings,
+                **flash_attn_kwargs,
+            )
+        else:
+            layer_outputs = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_values,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **flash_attn_kwargs,
+            )
+
+        hidden_states = layer_outputs[0]
+
+        if use_cache:
+            next_decoder_cache = layer_outputs[2 if output_attentions else 1]
+
+        if output_attentions:
+            all_self_attns += (layer_outputs[1],)
+
+    hidden_states = self.norm(hidden_states)
+
+    # add hidden states from the last decoder layer
+    if output_hidden_states:
+        all_hidden_states += (hidden_states,)
+
+    next_cache = next_decoder_cache if use_cache else None
+    if return_legacy_cache:
+        next_cache = next_cache.to_legacy_cache()
+
+    if not return_dict:
+        return tuple(v for v in [hidden_states, next_cache, all_hidden_states, all_self_attns] if v is not None)
+    return BaseModelOutputWithPast(
+        last_hidden_state=hidden_states,
+        past_key_values=next_cache,
+        hidden_states=all_hidden_states,
+        attentions=all_self_attns,
+    )
+
+def causal_model_forward(
+    self,
+    input_ids: torch.LongTensor = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+    inputs_embeds: Optional[torch.FloatTensor] = None,
+    labels: Optional[torch.LongTensor] = None,
+    use_cache: Optional[bool] = None,
+    output_attentions: Optional[bool] = None,
+    output_hidden_states: Optional[bool] = None,
+    return_dict: Optional[bool] = None,
+    cache_position: Optional[torch.LongTensor] = None,
+    num_logits_to_keep: int = 0,
+    **kwargs: Unpack[KwargsForCausalLM],
+) -> Union[Tuple, CausalLMOutputWithPast]:
+    output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+    fa_kwargs = dict(kwargs)
+    if 'num_items_in_batch' in fa_kwargs:
+        fa_kwargs.pop('num_items_in_batch')
+
+    outputs = self.model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        inputs_embeds=inputs_embeds,
+        use_cache=use_cache,
+        output_attentions=output_attentions,
+        output_hidden_states=output_hidden_states,
+        return_dict=return_dict,
+        cache_position=cache_position,
+        **fa_kwargs,
+    )
+
+    hidden_states = outputs[0]
+    # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+    logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
+
+    loss = None
+    if labels is not None:
+        loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+
+    if not return_dict:
+        output = (logits,) + outputs[1:]
+        return (loss,) + output if loss is not None else output
+
+    return CausalLMOutputWithPast(
+        loss=loss,
+        logits=logits,
+        past_key_values=outputs.past_key_values,
+        hidden_states=outputs.hidden_states,
+        attentions=outputs.attentions,
+    )
+
+def apply_default_monkey_patch_llama():
+    # we rewrite this function because we need to pass `flash_attn_kwargs` to model forward function and pass `num_items_in_batch` to loss_function simultaneously, but there are conflicts in transformers-4.47.0
+    # and we also need allow using flash_attn_kwargs whether gradient_checkpointing is True or False which is only allowed when gradient_checkpointing is False in transformers-4.47.0,
+    transformers.models.llama.modeling_llama.LlamaForCausalLM.forward=causal_model_forward
+    transformers.models.llama.modeling_llama.LlamaModel.forward=model_forward
+
 def apply_seq_parallel_monkey_patch(
     seq_algo, model, sp_size=None, enable_offload=False, offload_percent=0.
 ):
-    assert seq_algo in ["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
+    assert seq_algo in ["zigzag_ring_attn", "zigzag_ring_attn_varlen", "dist_flash_attn", "ulysses_attn", "data_parallel"], f"Invalid seq_algo: {seq_algo}"
     assert model in ["llama", "mistral"], f"Invalid model: {model}"
+    apply_default_monkey_patch_llama()
     if seq_algo == "data_parallel":
         return
     elif seq_algo == "zigzag_ring_attn" and model == "llama":
         apply_zigzag_ring_attn_monkey_patch_llama(sp_size=sp_size)
+    elif seq_algo == "zigzag_ring_attn_varlen" and model == "llama":
+        apply_zigzag_ring_attn_varlen_monkey_patch_llama(sp_size=sp_size)
     elif seq_algo == "dist_flash_attn" and model == "llama":
         apply_dist_flash_attn_monkey_patch_llama(sp_size=sp_size, enable_offload=enable_offload, offload_percent=offload_percent)
     elif seq_algo == "ulysses_attn" and model == "llama":

--- a/src/llamafactory/easy_context/zigzag_ring_attn/prepare_inputs.py
+++ b/src/llamafactory/easy_context/zigzag_ring_attn/prepare_inputs.py
@@ -1,6 +1,5 @@
 import torch
 
-
 def extract_local(value, rank, world_size, device, dim=1):
     value_chunks = value.chunk(2 * world_size, dim=dim)
     local_value = torch.cat(
@@ -10,6 +9,21 @@ def extract_local(value, rank, world_size, device, dim=1):
         return local_value
     return local_value.to(device)
 
+def extract_local_varlen(value, cu_seqlens, rank, world_size, device, dim=1):
+    local_values = []
+    for i in range(len(cu_seqlens) - 1):
+        start, end = cu_seqlens[i], cu_seqlens[i + 1]
+        local_value = value[:,start:end].chunk(2 * world_size, dim=dim)
+        local_values.extend(
+            [
+                local_value[rank].detach().clone(),
+                local_value[2 * world_size - 1 - rank].detach().clone(),
+            ]
+        )
+
+    if device == None:
+        return torch.cat(local_values, dim=dim).contiguous()
+    return torch.cat(local_values, dim=dim).contiguous().to(device)
 
 def prepare_zigzag_ring_attn_inputs(
     input_ids, position_ids, target_ids, rank, world_size, device
@@ -73,4 +87,37 @@ def prepare_zigzag_ring_attn_sft_inputs(
         "attention_mask": None,
         "position_ids": local_position_ids,
         "labels": local_labels,
+    }
+
+def prepare_zigzag_ring_attn_varlen_sft_inputs(
+    input_ids, attention_mask, position_ids, labels, rank, world_size, device, cu_seqlens, cu_seq_lens_q, max_length_q
+):
+    local_input_ids = extract_local_varlen(
+        input_ids,
+        cu_seqlens,
+        rank,
+        world_size,
+        device,
+    )
+    local_position_ids = extract_local_varlen(
+        position_ids,
+        cu_seqlens,
+        rank,
+        world_size,
+        device,
+    )
+    local_labels = extract_local_varlen(
+        labels,
+        cu_seqlens,
+        rank,
+        world_size,
+        device,
+    )
+    return {
+        "input_ids": local_input_ids,
+        "attention_mask": None,
+        "position_ids": local_position_ids,
+        "labels": local_labels,
+        "cu_seq_lens_q": cu_seq_lens_q,
+        "max_length_q": max_length_q
     }

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -312,9 +312,13 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         default=False,
         metadata={"help": "Whether or not to save the training loss curves."},
     )
-    parallel_mode: Literal["zigzag_ring_attn", "dist_flash_attn", "ulysses_attn", "data_parallel"] = field(
+    parallel_mode: Literal["zigzag_ring_attn", "zigzag_ring_attn_varlen", "dist_flash_attn", "ulysses_attn", "data_parallel"] = field(
         default="data_parallel",
         metadata={"help": "which sequence parallel mode to use."},
+    )
+    record_ppl: bool = field(
+        default=False,
+        metadata={"help": "whether to record the perplexity. Can only be used when learning rate is 0."},
     )
     sp_size: int = field(
         default=-1,

--- a/src/llamafactory/model/model_utils/checkpointing.py
+++ b/src/llamafactory/model/model_utils/checkpointing.py
@@ -83,7 +83,7 @@ def prepare_model_for_training(
             # use_reentrant=False might increase VRAM usage (have not been empirically verified yet)
             # According to: https://github.com/huggingface/transformers/issues/28339
             model.gradient_checkpointing_enable = MethodType(_gradient_checkpointing_enable, model)
-            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": True})
+            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
             setattr(model.config, "use_cache", False)  # turn off when gradient checkpointing is enabled
             logger.info("Gradient checkpointing enabled.")
 

--- a/src/llamafactory/train/pt/trainer.py
+++ b/src/llamafactory/train/pt/trainer.py
@@ -1,27 +1,31 @@
 from types import MethodType
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 from transformers import Trainer
 
 from ...extras.logging import get_logger
 from ..trainer_utils import create_custom_optimzer, create_custom_scheduler
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, SequentialSampler
 from transformers.utils import is_datasets_available
 from transformers.trainer_utils import seed_worker
 import datasets
+import torch.nn as nn
 from torch.nn import CrossEntropyLoss
 import os
-
+from transformers.training_args import OptimizerNames
+from transformers.trainer_pt_utils import _get_learning_rate
+from transformers.utils import is_apex_available
 if TYPE_CHECKING:
     import torch
     from transformers import ProcessorMixin
 
     from ...hparams import FinetuningArguments
 
-
 logger = get_logger(__name__)
 
+if is_apex_available():
+    from apex import amp
 
 class CustomTrainer(Trainer):
     r"""
@@ -57,17 +61,62 @@ class CustomTrainer(Trainer):
             getattr(self.processor, "image_processor").save_pretrained(output_dir)
 
 class CustomSeqParallelTrainer(CustomTrainer):
-    def compute_loss(self, model, inputs, return_outputs=False):
+        # diff from base trainer: always passing `num_items_in_batch` to compute_loss function
+    def training_step(
+        self, model: nn.Module, inputs: Dict[str, Union[torch.Tensor, Any]], num_items_in_batch=None
+    ) -> torch.Tensor:
+
+        model.train()
+        if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
+            self.optimizer.train()
+
+        inputs = self._prepare_inputs(inputs)
+
+        with self.compute_loss_context_manager():
+            loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
+
+        del inputs
+        if (
+            self.args.torch_empty_cache_steps is not None
+            and self.state.global_step % self.args.torch_empty_cache_steps == 0
+        ):
+            torch.cuda.empty_cache()
+
+        kwargs = {}
+
+        # For LOMO optimizers you need to explicitly use the learnign rate
+        if self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
+            kwargs["learning_rate"] = self._get_learning_rate()
+
+        if self.args.n_gpu > 1:
+            loss = loss.mean()  # mean() to average on multi-gpu parallel training
+
+        if self.use_apex:
+            with amp.scale_loss(loss, self.optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            self.accelerator.backward(loss, **kwargs)
+            # Finally we need to normalize the loss for reporting
+            if num_items_in_batch is None:
+                return loss.detach() / self.args.gradient_accumulation_steps
+            return loss.detach()
+
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         """
         How the loss is computed by Trainer. By default, all models return the loss in the first element.
 
         Subclass and override for custom behavior.
         """
         from transformers.trainer import _is_peft_model, MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
-        if self.label_smoother is not None and "labels" in inputs:
+        if (self.label_smoother is not None or self.compute_loss_func is not None) and "labels" in inputs:
             labels = inputs.pop("labels")
         else:
             labels = None
+        if self.model_accepts_loss_kwargs:
+            loss_kwargs = {}
+            if num_items_in_batch is not None:
+                loss_kwargs["num_items_in_batch"] = num_items_in_batch
+            inputs = {**inputs, **loss_kwargs}
         outputs = model(**inputs)
         # Save past state if it exists
         # TODO: this needs to be fixed and made cleaner later.
@@ -80,40 +129,62 @@ class CustomSeqParallelTrainer(CustomTrainer):
                 model_name = unwrapped_model.base_model.model._get_name()
             else:
                 model_name = unwrapped_model._get_name()
-            if model_name in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.values():
+            # User-defined compute_loss function
+            if self.compute_loss_func is not None:
+                loss = self.compute_loss_func(outputs, labels, num_items_in_batch=num_items_in_batch)
+            elif model_name in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.values():
                 loss = self.label_smoother(outputs, labels, shift_labels=True)
             else:
                 loss = self.label_smoother(outputs, labels)
         else:
-            if isinstance(outputs, dict) and "loss" not in outputs:
-                raise ValueError(
-                    "The model did not return a loss from the inputs, only the following keys: "
-                    f"{','.join(outputs.keys())}. For reference, the inputs it received are {','.join(inputs.keys())}."
-                )
             # We don't use .loss here since the model may return tuples instead of ModelOutput.
             if self.finetuning_args.parallel_mode== "data_parallel":
+                if isinstance(outputs, dict) and "loss" not in outputs:
+                    raise ValueError(
+                        "The model did not return a loss from the inputs, only the following keys: "
+                        f"{','.join(outputs.keys())}. For reference, the inputs it received are {','.join(inputs.keys())}."
+                    )
                 loss = outputs["loss"] if isinstance(outputs, dict) else outputs[0]
-
+                if not hasattr(self.args, 'average_tokens_across_devices'):
+                    self.args.average_tokens_across_devices = None
+                if not hasattr(self, 'model_accepts_loss_kwargs'):
+                    self.model_accepts_loss_kwargs= None
+                if self.args.average_tokens_across_devices and self.model_accepts_loss_kwargs:
+                    loss *= self.accelerator.num_processes
             else:
-                sp_size = self.finetuning_args.sp_size
-                loss_fn = CrossEntropyLoss(reduction='sum')
-                labels = inputs.pop("labels")
-                logits = outputs["logits"] if isinstance(outputs, dict) else outputs[1]
-                valid_label_cnt = (labels!=-100).sum(1)[None, :]
-                valid_label_cnt_gather = self.accelerator.gather(valid_label_cnt)
-                n_gpus = valid_label_cnt_gather.shape[0]
-                if sp_size == -1:
-                    sp_size = n_gpus
-                dp_rank = self.accelerator.process_index // sp_size
-                valid_label_cnt_all =valid_label_cnt_gather[dp_rank * sp_size : (dp_rank+1) * sp_size].sum(0).detach()
-                shift_logits = logits.contiguous()
-                shift_labels = labels.contiguous()
-                bs = len(shift_labels)
-                loss = torch.zeros(bs, dtype=shift_logits.dtype, device=shift_labels.device)
-                for b in range(bs):
-                    normalizer=valid_label_cnt_all[b].item()
-                    loss[b]=loss_fn(shift_logits[b], shift_labels[b])/normalizer
-                loss = loss.mean()*sp_size
+                if num_items_in_batch is None:
+                    sp_size = self.finetuning_args.sp_size
+                    loss_fn = CrossEntropyLoss(reduction='sum')
+                    labels = inputs.pop("labels")
+                    logits = outputs["logits"] if isinstance(outputs, dict) else outputs[1]
+                    valid_label_cnt = (labels!=-100).sum(1)[None, :]
+                    valid_label_cnt_gather = self.accelerator.gather(valid_label_cnt)
+                    n_gpus = valid_label_cnt_gather.shape[0]
+                    if sp_size == -1:
+                        sp_size = n_gpus
+                    dp_rank = self.accelerator.process_index // sp_size
+                    valid_label_cnt_all =valid_label_cnt_gather[dp_rank * sp_size : (dp_rank+1) * sp_size].sum(0).detach()
+                    shift_logits = logits.contiguous()
+                    shift_labels = labels.contiguous()
+                    bs = len(shift_labels)
+                    loss = torch.zeros(bs, dtype=shift_logits.dtype, device=shift_labels.device)
+                    for b in range(bs):
+                        normalizer=valid_label_cnt_all[b].item()
+                        loss[b]=loss_fn(shift_logits[b], shift_labels[b])/normalizer
+                    loss = loss.mean()*sp_size
+                else:
+                    assert self.args.average_tokens_across_devices is True, "please set average_tokens_across_devices=True if parallel_mode is not data_parallel"
+                    loss_fn = CrossEntropyLoss(reduction='sum')
+                    labels = inputs.pop("labels")
+                    logits = outputs["logits"] if isinstance(outputs, dict) else outputs[1]
+                    shift_logits = logits.contiguous()
+                    shift_labels = labels.contiguous()
+                    shift_logits = shift_logits.view(-1, self.model.config.vocab_size)
+                    shift_labels = shift_labels.view(-1)
+                    loss = loss_fn(shift_logits, shift_labels)/num_items_in_batch
+
+                    if self.args.average_tokens_across_devices and self.model_accepts_loss_kwargs:
+                        loss *= self.accelerator.num_processes
 
         return (loss, outputs) if return_outputs else loss
 

--- a/src/llamafactory/train/pt/workflow.py
+++ b/src/llamafactory/train/pt/workflow.py
@@ -28,6 +28,7 @@ def run_pt(
     finetuning_args: "FinetuningArguments",
     callbacks: Optional[List["TrainerCallback"]] = None,
 ):
+    assert finetuning_args.parallel_mode != "zigzag_ring_attn_varlen", "zigzag_ring_attn_varlen is not recommanded for continued pre-training"
     tokenizer_module = load_tokenizer(model_args)
     tokenizer = tokenizer_module["tokenizer"]
     dataset = get_dataset(model_args, data_args, training_args, stage="pt", **tokenizer_module)
@@ -37,7 +38,7 @@ def run_pt(
     # data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
     local_rank = int(os.getenv("LOCAL_RANK"))
     print(f"seq_len: {data_args.cutoff_len}")
-    
+
     data_collator = SeqParallelDataCollatorForLanguageModeling(
         tokenizer=tokenizer, 
         mlm=False,

--- a/src/llamafactory/train/sft/workflow.py
+++ b/src/llamafactory/train/sft/workflow.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, List, Optional
 from transformers import DataCollatorForSeq2Seq
 
 from ...data import get_dataset, split_dataset
-from ...data.collator import SeqParallelDataCollator
+from ...data.collator import SeqParallelDataCollator, SeqParallelDataCollatorWithFlattening
 from ...extras.constants import IGNORE_INDEX
 from ...extras.misc import get_logits_processor
 from ...extras.ploting import plot_loss
@@ -35,6 +35,8 @@ def run_sft(
 ):
     tokenizer_module = load_tokenizer(model_args)
     tokenizer = tokenizer_module["tokenizer"]
+    if tokenizer.slow_tokenizer_class =="Qwen2Tokenizer":
+        tokenizer.eos_token = "<|endoftext|>"
     dataset = get_dataset(model_args, data_args, training_args, stage="sft", **tokenizer_module)
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train)
     apply_seq_parallel_monkey_patch(finetuning_args.parallel_mode, "llama", sp_size=finetuning_args.sp_size, enable_offload=finetuning_args.sp_enable_offload, offload_percent=finetuning_args.sp_offload_percent)
@@ -48,16 +50,26 @@ def run_sft(
     local_rank = int(os.getenv("LOCAL_RANK"))
     world_size = torch.distributed.get_world_size()
     print(f"seq_len: {data_args.cutoff_len}")
-    data_collator = SeqParallelDataCollator(
-        tokenizer=tokenizer,
-        pad_to_multiple_of=data_args.cutoff_len if tokenizer.padding_side == "right" else None,
-        label_pad_token_id=IGNORE_INDEX if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id,
-        seq_algo=finetuning_args.parallel_mode,
-        sp_size=finetuning_args.sp_size,
-        rank=torch.distributed.get_rank(),
-        world_size=world_size,
-        device=torch.device("cuda", local_rank)
-    )
+    if finetuning_args.parallel_mode == "zigzag_ring_attn_varlen":
+        data_collator = SeqParallelDataCollatorWithFlattening(
+            tokenizer=tokenizer,
+            seq_algo="zigzag_ring_attn_varlen",
+            sp_size=finetuning_args.sp_size,
+            rank=torch.distributed.get_rank(),
+            world_size=world_size,
+            device=torch.device("cuda", local_rank)
+        )
+    else:
+        data_collator = SeqParallelDataCollator(
+            tokenizer=tokenizer,
+            pad_to_multiple_of=data_args.cutoff_len if tokenizer.padding_side == "right" else None,
+            label_pad_token_id=IGNORE_INDEX if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id,
+            seq_algo=finetuning_args.parallel_mode,
+            sp_size=finetuning_args.sp_size,
+            rank=torch.distributed.get_rank(),
+            world_size=world_size,
+            device=torch.device("cuda", local_rank)
+        )
     # Override the decoding parameters of Seq2SeqTrainer
     training_args.generation_max_length = training_args.generation_max_length or data_args.cutoff_len
     training_args.generation_num_beams = data_args.eval_num_beams or training_args.generation_num_beams


### PR DESCRIPTION
增加zigzag varlen

去掉了对transfomers-4.47.0之前的兼容逻辑

测试loss一致性结果：
1. data_parallel
<img width="493" alt="1735197966334_9980FA4B-FA72-4716-B1A7-6198CE6752C5" src="https://github.com/user-attachments/assets/2174fe36-7d79-4383-b450-f9b6c9cbe090" />

2. zigzag
<img width="494" alt="1735198541010_C1C4BFD2-41BB-4937-9F43-05463897B2D3" src="https://github.com/user-attachments/assets/e51d8e0b-019a-42ce-a0b0-8c80086f9ff4" />

3. dist_flash_attn
<img width="519" alt="1735200025050_975E7847-482C-48a3-91A4-5FFDFE79D8AE" src="https://github.com/user-attachments/assets/f9e345f3-04a2-4b5f-b5e5-67268c5155bc" />

4. zigzag_varlen
<img width="498" alt="1735200403556_572EAF39-11C0-4b5c-BABF-E71326E35A47" src="https://github.com/user-attachments/assets/0e29d4a0-f56c-4353-bd87-25d41ab46f14" />
