### PR TITLE
new dynamic dp-sp for transformers-4.47

### DIFF
--- a/src/llamafactory/dynamic_sp/trainer.py
+++ b/src/llamafactory/dynamic_sp/trainer.py
@@ -1,0 +1,842 @@
+from types import MethodType
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+import math, os, functools, contextlib, time, sys, shutil
+import torch
+import torch.nn as nn
+import torch.distributed as dist
+from transformers import Seq2SeqTrainer, Trainer
+from torch.utils.data import DataLoader
+from transformers.integrations.tpu import tpu_spmd_dataloader
+from transformers.trainer_utils import (
+    HPSearchBackend,
+    SaveStrategy,
+    TrainOutput,
+    has_length,
+    speed_metrics,
+    seed_worker
+)
+from transformers.debug_utils import DebugOption, DebugUnderflowOverflow
+from transformers.utils import is_sagemaker_mp_enabled, is_torch_xla_available, is_accelerate_available, is_apex_available, is_datasets_available
+from transformers.integrations import hp_params
+from transformers.integrations.deepspeed import deepspeed_init, deepspeed_load_checkpoint, is_deepspeed_available
+from transformers.trainer_callback import TrainerState, ExportableState
+from transformers.modeling_utils import unwrap_model
+from transformers.training_args import OptimizerNames, ParallelMode
+from transformers.trainer import _is_peft_model, TRAINER_STATE_NAME
+from transformers.trainer_pt_utils import get_model_param_count
+from accelerate import skip_first_batches
+from accelerate.utils import DistributedType
+from ..train.trainer_utils import create_custom_optimzer, create_custom_scheduler
+from ..extras.logging import get_logger
+if TYPE_CHECKING:
+    from transformers import ProcessorMixin
+    from transformers.trainer import PredictionOutput
+    from ..hparams import FinetuningArguments
+import datasets
+from ..easy_context import prepare_dynamic_sp, prepare_seq_parallel_sft_inputs
+
+logger = get_logger(__name__)
+
+if is_apex_available():
+    from apex import amp
+
+if is_torch_xla_available():
+    import torch_xla.core.xla_model as xm
+    import torch_xla.debug.metrics as met
+
+if is_sagemaker_mp_enabled():
+    import smdistributed.modelparallel.torch as smp
+
+class DynamicSequenceParallelTrainer(Trainer):
+
+    def __init__(
+        self, finetuning_args: "FinetuningArguments", processor: Optional["ProcessorMixin"], cutoff_len: int, **kwargs
+    ) -> None:
+        super().__init__(**kwargs)
+        self.finetuning_args = finetuning_args
+        self.processor = processor
+        eps = 1e-5
+        cache_len = int(math.log2(max(cutoff_len // self.finetuning_args.seqlen_per_gpu+eps, 1)))+1
+        self.cutoff_len = cutoff_len
+        self.cache = [[] for _ in range(cache_len)]
+        self.world_size = torch.distributed.get_world_size()
+        self.total_bs = self.finetuning_args.total_batch_size
+        self.batch_steps = self.total_bs // self._train_batch_size
+        self.dp_flatten_table = []
+        self.dp_choices = {}
+
+    def create_optimizer(self) -> "torch.optim.Optimizer":
+        if self.optimizer is None:
+            self.optimizer = create_custom_optimzer(self.model, self.args, self.finetuning_args)
+        return super().create_optimizer()
+
+    def create_scheduler(
+        self, num_training_steps: int, optimizer: Optional["torch.optim.Optimizer"] = None
+    ) -> "torch.optim.lr_scheduler.LRScheduler":
+        create_custom_scheduler(self.args, num_training_steps, optimizer)
+        return super().create_scheduler(num_training_steps, optimizer)
+
+    def _save(self, output_dir: Optional[str] = None, state_dict: Optional[Dict[str, "torch.Tensor"]] = None) -> None:
+        super()._save(output_dir, state_dict)
+        if self.processor is not None:
+            output_dir = output_dir if output_dir is not None else self.args.output_dir
+            getattr(self.processor, "image_processor").save_pretrained(output_dir)
+
+    def _try_get_data_from_cache(self, degrade=False):
+        total_dp_size = self.batch_steps
+        # prepare dp_flatten_table for dynamic programming
+        # the reason why using dp_flatten_table rather than cache is to ensure that each data_parallel rank has the same data seq_len in a data_parallel group
+        for i, data in enumerate(self.cache):
+            flatten_num = (len(data) << i // self.world_size * self.world_size) >> i
+            for _ in range(flatten_num // (self.world_size >> i)):
+                flatten_data = self.cache[i][:flatten_num]
+                self.cache[i] = self.cache[i][flatten_num:]
+                self.dp_flatten_table.append(flatten_data)
+        if sum([len(x) for x in self.dp_flatten_table]) < total_dp_size:
+            return None
+
+        self.dp_choices[0]=0
+        success=False
+
+        # execute dynamic programming and record choice by `dp_choices`
+        for i, dp_flatten_data in enumerate(self.dp_flatten_table):
+            if total_dp_size in self.dp_choices:
+                success=True
+                break
+            dp_list = list(self.dp_choices.keys())
+            for dps in dp_list:
+                k=dps+len(dp_flatten_data)
+                if k in self.dp_choices or k > total_dp_size:
+                    continue
+                else:
+                    self.dp_choices[k] = self.dp_choices[dps] + (1<<i)
+
+        if success:
+            choice = self.dp_choices[total_dp_size]
+            data = []
+            for i in reversed(range(len(self.dp_flatten_table))):
+                if choice & 1<<i:
+                    data.append(self.dp_flatten_table.pop(i))
+            self.dp_choices = {}
+            return data
+
+        # degrade: find the closest choice to total_dp_size
+        if degrade:
+            choice = 0
+            for i in range(1, total_dp_size):
+                if total_dp_size-i in self.dp_choices:
+                    choice = self.dp_choices[total_dp_size-i]
+                    break
+            data = []
+            for i in reversed(range(len(self.dp_flatten_table))):
+                if choice & 1<<i:
+                    data.append(self.dp_flatten_table.pop(i))
+            self.dp_choices = {}
+            return data
+        return None
+
+    def _fill_cache(self, batch):
+        batch_len = batch["input_ids"].shape[1]
+        eps=1e-5
+        i = int(math.log2(batch_len // self.finetuning_args.seqlen_per_gpu)+eps)
+        self.cache[i].append(batch)
+
+    def get_batch_samples(self, epoch_iterator):
+        assert self.args.average_tokens_across_devices, "`average_tokens_across_devices` must be True"
+        num_items_in_batch = None
+        degrade = False
+        batch_samples = self._try_get_data_from_cache(degrade)
+        while batch_samples is None:
+            if sum([len(x) for x in self.dp_flatten_table]) >= 2*self.batch_steps:
+                degrade = True
+            try:
+                batch = next(epoch_iterator)
+            except StopIteration:
+                break
+            for k in batch:
+                batch[k]=batch[k][:self.cutoff_len]
+            self._fill_cache(batch)
+            batch_samples = self._try_get_data_from_cache(degrade)
+        # Keep default behavior the same
+        if not self.model_accepts_loss_kwargs:
+            return batch_samples, None
+
+        if len(batch_samples) > 0 and "labels" in batch_samples[0][0]:
+            # For now we don't support object detection
+            try:
+                num_items_in_batch = sum([sum([(batch["labels"].ne(-100)).sum() for batch in micro_batch_samples]) for micro_batch_samples in batch_samples])
+            except (TypeError, AttributeError):
+                pass
+        return batch_samples, num_items_in_batch
+
+    def _dispatch_batch(self, batch_samples):
+        dispatched_batch_samples = []
+        for sample in batch_samples:
+            dp_size = len(sample)
+            sp_size = self.world_size // dp_size
+            for batch_data in sample:
+                batch_data['dp_size'] = dp_size
+                batch_data['sp_size'] = sp_size
+            dp_index = torch.distributed.get_rank() // sp_size
+            dispatched_batch_samples.append(sample[dp_index])
+        return dispatched_batch_samples
+
+    def training_step(
+        self, model: nn.Module, inputs: Dict[str, Union[torch.Tensor, Any]], num_items_in_batch=None
+    ) -> torch.Tensor:
+        """
+        Perform a training step on a batch of inputs.
+
+        Subclass and override to inject custom behavior.
+
+        Args:
+            model (`nn.Module`):
+                The model to train.
+            inputs (`Dict[str, Union[torch.Tensor, Any]]`):
+                The inputs and targets of the model.
+
+                The dictionary will be unpacked before being fed to the model. Most models expect the targets under the
+                argument `labels`. Check your model's documentation for all accepted arguments.
+
+        Return:
+            `torch.Tensor`: The tensor with training loss on this batch.
+        """
+        model.train()
+        if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
+            self.optimizer.train()
+
+        inputs = self._prepare_inputs(inputs)
+        if is_sagemaker_mp_enabled():
+            loss_mb = smp_forward_backward(model, inputs, self.args.gradient_accumulation_steps)
+            return loss_mb.reduce_mean().detach().to(self.args.device)
+        with self.compute_loss_context_manager():
+            loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
+
+        del inputs
+        if (
+            self.args.torch_empty_cache_steps is not None
+            and self.state.global_step % self.args.torch_empty_cache_steps == 0
+        ):
+            torch.cuda.empty_cache()
+
+        kwargs = {}
+
+        # For LOMO optimizers you need to explicitly use the learnign rate
+        if self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
+            kwargs["learning_rate"] = self._get_learning_rate()
+
+        if self.args.n_gpu > 1:
+            loss = loss.mean()  # mean() to average on multi-gpu parallel training
+
+        if self.use_apex:
+            with amp.scale_loss(loss, self.optimizer) as scaled_loss:
+                scaled_loss.backward()
+        else:
+            self.accelerator.backward(loss, **kwargs)
+            # Finally we need to normalize the loss for reporting
+            return loss.detach()
+                                                           
+    def _inner_training_loop(
+        self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
+    ):
+        self.accelerator.free_memory()
+        self._train_batch_size = batch_size
+        if self.args.auto_find_batch_size:
+            if self.state.train_batch_size != self._train_batch_size:
+                from accelerate.utils import release_memory
+
+                (self.model_wrapped,) = release_memory(self.model_wrapped)
+                self.model_wrapped = self.model
+
+                # Check for DeepSpeed *after* the intial pass and modify the config
+                if self.is_deepspeed_enabled:
+                    # Temporarily unset `self.args.train_batch_size`
+                    original_bs = self.args.per_device_train_batch_size
+                    self.args.per_device_train_batch_size = self._train_batch_size // max(1, self.args.n_gpu)
+                    self.propagate_args_to_deepspeed(True)
+                    self.args.per_device_train_batch_size = original_bs
+            self.state.train_batch_size = self._train_batch_size
+        logger.debug(f"Currently training with a batch size of: {self._train_batch_size}")
+        # Data loader and number of training steps
+        train_dataloader = self.get_train_dataloader()
+        if self.is_fsdp_xla_v2_enabled:
+            train_dataloader = tpu_spmd_dataloader(train_dataloader)
+
+        # Setting up training control variables:
+        # number of training epochs: num_train_epochs
+        # number of training steps per epoch: num_update_steps_per_epoch
+        # total number of training steps to execute: max_steps
+        total_train_batch_size = self.total_bs
+        data_collator = self.data_collator
+
+        len_dataloader = None
+        num_train_tokens = None
+        if has_length(train_dataloader):
+            len_dataloader = len(train_dataloader)
+            num_update_steps_per_epoch = len_dataloader // self.batch_steps
+            num_update_steps_per_epoch = max(num_update_steps_per_epoch, 1)
+            num_examples = self.num_examples(train_dataloader)
+            if args.max_steps > 0:
+                max_steps = args.max_steps
+                num_train_epochs = args.max_steps // num_update_steps_per_epoch + int(
+                    args.max_steps % num_update_steps_per_epoch > 0
+                )
+                # May be slightly incorrect if the last batch in the training dataloader has a smaller size but it's
+                # the best we can do.
+                num_train_samples = args.max_steps * total_train_batch_size
+                if args.include_tokens_per_second:
+                    num_train_tokens = (
+                        self.num_tokens(train_dataloader, args.max_steps * self.batch_steps)
+                    )
+            else:
+                max_steps = math.ceil(args.num_train_epochs * num_update_steps_per_epoch)
+                num_train_epochs = math.ceil(args.num_train_epochs)
+                num_train_samples = self.num_examples(train_dataloader) * args.num_train_epochs
+                if args.include_tokens_per_second:
+                    num_train_tokens = self.num_tokens(train_dataloader) * args.num_train_epochs
+        elif args.max_steps > 0:  # Rely on max_steps when dataloader does not have a working size
+            max_steps = args.max_steps
+            # Setting a very large number of epochs so we go as many times as necessary over the iterator.
+            num_train_epochs = sys.maxsize
+            num_update_steps_per_epoch = max_steps
+            num_examples = total_train_batch_size * args.max_steps
+            num_train_samples = args.max_steps * total_train_batch_size
+            if args.include_tokens_per_second:
+                num_train_tokens = self.num_tokens(train_dataloader, args.max_steps * self.batch_step)
+        else:
+            raise ValueError(
+                "args.max_steps must be set to a positive value if dataloader does not have a length, was"
+                f" {args.max_steps}"
+            )
+
+        if DebugOption.UNDERFLOW_OVERFLOW in self.args.debug:
+            if self.args.n_gpu > 1:
+                # nn.DataParallel(model) replicates the model, creating new variables and module
+                # references registered here no longer work on other gpus, breaking the module
+                raise ValueError(
+                    "Currently --debug underflow_overflow is not supported under DP. Please use DDP"
+                    " (torchrun or torch.distributed.launch (deprecated))."
+                )
+            else:
+                debug_overflow = DebugUnderflowOverflow(self.model)  # noqa
+
+        delay_optimizer_creation = is_sagemaker_mp_enabled() or self.is_fsdp_xla_enabled
+
+        # We need to reset the scheduler, as its parameters may be different on subsequent calls
+        if self._created_lr_scheduler:
+            self.lr_scheduler = None
+            self._created_lr_scheduler = False
+
+        if self.is_deepspeed_enabled:
+            self.optimizer, self.lr_scheduler = deepspeed_init(self, num_training_steps=max_steps)
+
+        if not delay_optimizer_creation:
+            self.create_optimizer_and_scheduler(num_training_steps=max_steps)
+
+        self.state = TrainerState(
+            stateful_callbacks=[
+                cb for cb in self.callback_handler.callbacks + [self.control] if isinstance(cb, ExportableState)
+            ]
+        )
+        self.state.is_hyper_param_search = trial is not None
+        self.state.train_batch_size = self._train_batch_size
+
+        # Compute absolute values for logging, eval, and save if given as ratio
+        if args.logging_steps is not None:
+            if args.logging_steps < 1:
+                self.state.logging_steps = math.ceil(max_steps * args.logging_steps)
+            else:
+                self.state.logging_steps = args.logging_steps
+        if args.eval_steps is not None:
+            if args.eval_steps < 1:
+                self.state.eval_steps = math.ceil(max_steps * args.eval_steps)
+            else:
+                self.state.eval_steps = args.eval_steps
+        if args.save_steps is not None:
+            if args.save_steps < 1:
+                self.state.save_steps = math.ceil(max_steps * args.save_steps)
+            else:
+                self.state.save_steps = args.save_steps
+
+        # Activate gradient checkpointing if needed
+        if args.gradient_checkpointing:
+            self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=args.gradient_checkpointing_kwargs)
+
+        model = self._wrap_model(self.model_wrapped)
+
+        # as the model is wrapped, don't use `accelerator.prepare`
+        # this is for unhandled cases such as
+        # FSDP-XLA, SageMaker MP/DP, DataParallel, IPEX
+        use_accelerator_prepare = True if model is self.model else False
+
+        if use_accelerator_prepare and self.is_fsdp_enabled:
+            # In case of auto_find_batch_size=True
+            # Remove FSDP wrapping from sub-models.
+            self.model = unwrap_model(self.model, recursive=True)
+            # configure fsdp plugin for qlora if any
+            self._fsdp_qlora_plugin_updates()
+
+        if delay_optimizer_creation:
+            if use_accelerator_prepare:
+                self.model = self.accelerator.prepare(self.model)
+            self.create_optimizer_and_scheduler(num_training_steps=max_steps)
+
+        # prepare using `accelerator` prepare
+        if use_accelerator_prepare:
+            self.model.train()
+            if hasattr(self.lr_scheduler, "step"):
+                if self.use_apex:
+                    model = self.accelerator.prepare(self.model)
+                else:
+                    model, self.optimizer = self.accelerator.prepare(self.model, self.optimizer)
+            else:
+                # to handle cases wherein we pass "DummyScheduler" such as when it is specified in DeepSpeed config.
+                model, self.optimizer, self.lr_scheduler = self.accelerator.prepare(
+                    self.model, self.optimizer, self.lr_scheduler
+                )
+        elif self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
+            # In this case we are in DDP + LOMO, which should be supported
+            self.optimizer = self.accelerator.prepare(self.optimizer)
+
+        if self.is_fsdp_enabled:
+            self.model = self.model_wrapped = model
+
+        # for the rest of this function `model` is the outside model, whether it was wrapped or not
+        if model is not self.model:
+            self.model_wrapped = model
+
+        # backward compatibility
+        if self.is_deepspeed_enabled:
+            self.deepspeed = self.model_wrapped
+
+        # ckpt loading
+        if resume_from_checkpoint is not None:
+            if self.is_deepspeed_enabled:
+                deepspeed_load_checkpoint(
+                    self.model_wrapped, resume_from_checkpoint, load_module_strict=not _is_peft_model(self.model)
+                )
+            elif is_sagemaker_mp_enabled() or self.is_fsdp_enabled:
+                self._load_from_checkpoint(resume_from_checkpoint, self.model_wrapped)
+
+        # Check if saved optimizer or scheduler states exist
+        self._load_optimizer_and_scheduler(resume_from_checkpoint)
+
+        # important: at this point:
+        # self.model         is the Transformers Model
+        # self.model_wrapped is DDP(Transformers Model), Deepspeed(Transformers Model),
+        # FSDP(Transformers Model), Dynamo Optimized Module(Transformers Model) etc.
+
+        # Train!
+        logger.info("***** Running training *****")
+        logger.info(f"  Num examples = {num_examples:,}")
+        logger.info(f"  Num Epochs = {num_train_epochs:,}")
+        logger.info(f"  Instantaneous batch size per device = {self.args.per_device_train_batch_size:,}")
+        if self.args.per_device_train_batch_size != self._train_batch_size:
+            logger.info(f"  Training with DataParallel so batch size has been adjusted to: {self._train_batch_size:,}")
+        logger.info(f"  Total train batch size (w. parallel, distributed & accumulation) = {total_train_batch_size:,}")
+        # logger.info(f"  Gradient Accumulation steps = {args.gradient_accumulation_steps}")
+        logger.info(f"  Total optimization steps = {max_steps:,}")
+        logger.info(f"  Number of trainable parameters = {get_model_param_count(model, trainable_only=True):,}")
+
+        self.state.epoch = 0
+        start_time = time.time()
+        epochs_trained = 0
+        steps_trained_in_current_epoch = 0
+        steps_trained_progress_bar = None
+
+        # Check if continuing training from a checkpoint
+        if resume_from_checkpoint is not None and os.path.isfile(
+            os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME)
+        ):
+            self.state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
+            self.compare_trainer_and_checkpoint_args(self.args, self.state)
+            self._load_callback_state()
+            epochs_trained = int(self.state.global_step // num_update_steps_per_epoch)
+            if not args.ignore_data_skip:
+                steps_trained_in_current_epoch = self.state.global_step % (num_update_steps_per_epoch)
+                steps_trained_in_current_epoch *= self.batch_steps
+            else:
+                steps_trained_in_current_epoch = 0
+
+            logger.info("  Continuing training from checkpoint, will skip to saved global_step")
+            logger.info(f"  Continuing training from epoch {epochs_trained}")
+            logger.info(f"  Continuing training from global step {self.state.global_step}")
+            if not args.ignore_data_skip:
+                logger.info(
+                    f"  Will skip the first {epochs_trained} epochs then the first"
+                    f" {steps_trained_in_current_epoch} batches in the first epoch."
+                )
+
+        # Update the references
+        self.callback_handler.model = self.model
+        self.callback_handler.optimizer = self.optimizer
+        self.callback_handler.lr_scheduler = self.lr_scheduler
+        self.callback_handler.train_dataloader = train_dataloader
+        if self.hp_name is not None and self._trial is not None:
+            # use self._trial because the SigOpt/Optuna hpo only call `_hp_search_setup(trial)` instead of passing trial
+            # parameter to Train when using DDP.
+            self.state.trial_name = self.hp_name(self._trial)
+        if trial is not None:
+            assignments = trial.assignments if self.hp_search_backend == HPSearchBackend.SIGOPT else trial
+            self.state.trial_params = hp_params(assignments)
+        else:
+            self.state.trial_params = None
+        # This should be the same if the state has been saved but in case the training arguments changed, it's safer
+        # to set this after the load.
+        self.state.max_steps = max_steps
+        self.state.num_train_epochs = num_train_epochs
+        self.state.is_local_process_zero = self.is_local_process_zero()
+        self.state.is_world_process_zero = self.is_world_process_zero()
+
+        # tr_loss is a tensor to avoid synchronization of TPUs through .item()
+        tr_loss = torch.tensor(0.0).to(args.device)
+        # _total_loss_scalar is updated everytime .item() has to be called on tr_loss and stores the sum of all losses
+        self._total_loss_scalar = 0.0
+        self._globalstep_last_logged = self.state.global_step
+        model.zero_grad()
+        grad_norm: Optional[float] = None
+        self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
+
+        if args.eval_on_start:
+            self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
+
+        for epoch in range(epochs_trained, num_train_epochs):
+            epoch_dataloader = train_dataloader
+            if hasattr(epoch_dataloader, "set_epoch"):
+                epoch_dataloader.set_epoch(epoch)
+
+            # Reset the past mems state at the beginning of each epoch if necessary.
+            if args.past_index >= 0:
+                self._past = None
+
+            steps_in_epoch = (
+                len(epoch_dataloader)
+                if len_dataloader is not None
+                else args.max_steps * self.batch_steps
+            )
+            self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
+
+            if epoch == epochs_trained and resume_from_checkpoint is not None and steps_trained_in_current_epoch == 0:
+                self._load_rng_state(resume_from_checkpoint)
+
+            rng_to_sync = False
+            steps_skipped = 0
+            if steps_trained_in_current_epoch > 0:
+                epoch_dataloader = skip_first_batches(epoch_dataloader, steps_trained_in_current_epoch)
+                steps_skipped = steps_trained_in_current_epoch
+                steps_trained_in_current_epoch = 0
+                rng_to_sync = True
+
+            step = -1
+            cur_dp_size = 0
+            epoch_iterator = iter(epoch_dataloader)
+            # We chunkify the epoch iterator into gradient accumulation steps `n` batches
+            remainder = num_examples % self.batch_steps
+            if remainder == 0:
+                remainder = self.batch_steps
+            update_step = -1
+            total_updates = steps_in_epoch + 1
+            for _ in range(total_updates):
+                update_step += 1
+                batch_samples, num_items_in_batch = self.get_batch_samples(epoch_iterator)
+                batch_samples = self._dispatch_batch(batch_samples)
+                for i, inputs in enumerate(batch_samples):
+                    dp_size = inputs.pop('dp_size')
+                    sp_size = inputs.pop('sp_size')
+                    step += dp_size
+                    prepare_dynamic_sp(seq_algo=self.finetuning_args.parallel_mode, sp_size=sp_size, model=model)
+                    labels = inputs['labels']
+                    padded_label = torch.concat([labels, self.data_collator.label_pad_token_id * torch.ones([labels.shape[0], inputs['input_ids'].shape[1]-labels.shape[1]], dtype=labels.dtype, device=labels.device)], axis=1)
+                    local_rank = int(os.getenv("LOCAL_RANK"))
+                    inputs = prepare_seq_parallel_sft_inputs(
+                        seq_algo=self.finetuning_args.parallel_mode,
+                        input_ids=inputs['input_ids'],
+                        attention_mask=inputs['attention_mask'],
+                        position_ids=None,
+                        labels=padded_label,
+                        rank=torch.distributed.get_rank() % sp_size,
+                        world_size=sp_size,
+                        device=torch.device("cuda", local_rank)
+                    )
+                    do_sync_step = (cur_dp_size + dp_size) % self.batch_steps == 0 or (step + self.world_size) >= steps_in_epoch
+                    # Since we perform prefetching, we need to manually set sync_gradients
+                    if not do_sync_step:
+                        self.accelerator.gradient_state._set_sync_gradients(False)
+                    else:
+                        self.accelerator.gradient_state._set_sync_gradients(True)
+
+                    if self.args.include_num_input_tokens_seen:
+                        main_input_name = getattr(self.model, "main_input_name", "input_ids")
+                        if main_input_name not in inputs:
+                            logger.warning(
+                                "Tried to track the number of tokens seen, however the current model is "
+                                "not configured properly to know what item is the input. To fix this, add "
+                                "a `main_input_name` attribute to the model class you are using."
+                            )
+                        else:
+                            input_tokens = inputs[main_input_name].numel()
+                            input_tokens = torch.tensor(input_tokens, device=self.args.device, dtype=torch.int64)
+                            self.state.num_input_tokens_seen += (
+                                self.accelerator.gather(input_tokens).sum().cpu().item()
+                            )
+                    if rng_to_sync:
+                        self._load_rng_state(resume_from_checkpoint)
+                        rng_to_sync = False
+
+                    # Skip past any already trained steps if resuming training
+                    if steps_trained_in_current_epoch > 0:
+                        steps_trained_in_current_epoch -= 1
+                        if steps_trained_progress_bar is not None:
+                            steps_trained_progress_bar.update(1)
+                        if steps_trained_in_current_epoch == 0:
+                            self._load_rng_state(resume_from_checkpoint)
+                        continue
+                    elif steps_trained_progress_bar is not None:
+                        steps_trained_progress_bar.close()
+                        steps_trained_progress_bar = None
+
+                    if cur_dp_size % self.batch_steps == 0:
+                        self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
+
+                    # We explicitly want to avoid relying on `accelerator.accumulate` for generation training
+                    context = (
+                        functools.partial(self.accelerator.no_sync, model=model)
+                        if i != len(batch_samples) - 1
+                        else contextlib.nullcontext
+                    )
+                    with context():
+                        tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
+
+                    if (
+                        args.logging_nan_inf_filter
+                        and not is_torch_xla_available()
+                        and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))
+                    ):
+                        # if loss is nan or inf simply add the average of previous logged losses
+                        tr_loss = tr_loss + tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                    else:
+                        if tr_loss.device != tr_loss_step.device:
+                            raise ValueError(
+                                f"Calculated loss must be on the original device: {tr_loss.device} but device in use is {tr_loss_step.device}"
+                            )
+                        tr_loss = tr_loss + tr_loss_step
+
+                    self.current_flos += float(self.floating_point_ops(inputs))
+                    cur_dp_size += dp_size
+                    if do_sync_step:
+                        # Since we perform prefetching, we need to manually set sync_gradients to True
+                        self.accelerator.gradient_state._set_sync_gradients(True)
+
+                        # Gradient clipping
+                        if args.max_grad_norm is not None and args.max_grad_norm > 0:
+                            # deepspeed does its own clipping
+
+                            if is_sagemaker_mp_enabled() and args.fp16:
+                                _grad_norm = self.optimizer.clip_master_grads(args.max_grad_norm)
+                            elif self.use_apex:
+                                # Revert to normal clipping otherwise, handling Apex or full precision
+                                _grad_norm = nn.utils.clip_grad_norm_(
+                                    amp.master_params(self.optimizer),
+                                    args.max_grad_norm,
+                                )
+                            else:
+                                _grad_norm = self.accelerator.clip_grad_norm_(
+                                    model.parameters(),
+                                    args.max_grad_norm,
+                                )
+
+                            if (
+                                is_accelerate_available()
+                                and self.accelerator.distributed_type == DistributedType.DEEPSPEED
+                            ):
+                                grad_norm = model.get_global_grad_norm()
+                                # In some cases the grad norm may not return a float
+                                if hasattr(grad_norm, "item"):
+                                    grad_norm = grad_norm.item()
+                            else:
+                                grad_norm = _grad_norm
+
+                        self.control = self.callback_handler.on_pre_optimizer_step(args, self.state, self.control)
+
+                        self.optimizer.step()
+
+                        self.control = self.callback_handler.on_optimizer_step(args, self.state, self.control)
+
+                        optimizer_was_run = not self.accelerator.optimizer_step_was_skipped
+                        if optimizer_was_run:
+                            # Delay optimizer scheduling until metrics are generated
+                            if not isinstance(self.lr_scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
+                                self.lr_scheduler.step()
+
+                        model.zero_grad()
+                        self.state.global_step += 1
+                        self.state.epoch = epoch + (step + 1 + steps_skipped) / steps_in_epoch
+                        self.control = self.callback_handler.on_step_end(args, self.state, self.control)
+                        self._maybe_log_save_evaluate(
+                            tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time
+                        )
+                    else:
+                        self.control = self.callback_handler.on_substep_end(args, self.state, self.control)
+
+                    # PyTorch/XLA relies on the data loader to insert the mark_step for
+                    # each step. Since we are breaking the loop early, we need to manually
+                    # insert the mark_step here.
+                    if self.control.should_epoch_stop or self.control.should_training_stop:
+                        if is_torch_xla_available():
+                            xm.mark_step()
+                        break
+                # We also need to break out of the nested loop
+                if self.control.should_epoch_stop or self.control.should_training_stop:
+                    if is_torch_xla_available():
+                        xm.mark_step()
+                    break
+            if step < 0:
+                logger.warning(
+                    "There seems not to be a single sample in your epoch_iterator, stopping training at step"
+                    f" {self.state.global_step}! This is expected if you're using an IterableDataset and set"
+                    f" num_steps ({max_steps}) higher than the number of available samples."
+                )
+                self.control.should_training_stop = True
+
+            self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
+            self._maybe_log_save_evaluate(tr_loss, grad_norm, model, trial, epoch, ignore_keys_for_eval, start_time)
+
+            if DebugOption.TPU_METRICS_DEBUG in self.args.debug:
+                if is_torch_xla_available():
+                    # tpu-comment: Logging debug metrics for PyTorch/XLA (compile, execute times, ops, etc.)
+                    xm.master_print(met.metrics_report())
+                else:
+                    logger.warning(
+                        "You enabled PyTorch/XLA debug metrics but you don't have a TPU "
+                        "configured. Check your training configuration if this is unexpected."
+                    )
+            if self.control.should_training_stop:
+                break
+
+        if args.past_index and hasattr(self, "_past"):
+            # Clean the state at the end of training
+            delattr(self, "_past")
+
+        logger.info("\n\nTraining completed. Do not forget to share your model on huggingface.co/models =)\n\n")
+        if args.load_best_model_at_end and self.state.best_model_checkpoint is not None:
+            # Wait for everyone to get here so we are sure the model has been saved by process 0.
+            if is_torch_xla_available():
+                xm.rendezvous("load_best_model_at_end")
+            elif args.parallel_mode == ParallelMode.DISTRIBUTED:
+                dist.barrier()
+            elif is_sagemaker_mp_enabled():
+                smp.barrier()
+
+            self._load_best_model()
+
+        # add remaining tr_loss
+        self._total_loss_scalar += tr_loss.item()
+        effective_global_step = max(self.state.global_step, 0.001)  # Avoid ZeroDivisionError
+        train_loss = self._total_loss_scalar / effective_global_step
+
+        metrics = speed_metrics(
+            "train",
+            start_time,
+            num_samples=num_train_samples,
+            num_steps=self.state.max_steps,
+            num_tokens=num_train_tokens,
+        )
+        self.store_flos()
+        metrics["total_flos"] = self.state.total_flos
+        metrics["train_loss"] = train_loss
+
+        self.is_in_train = False
+
+        self._memory_tracker.stop_and_update_metrics(metrics)
+
+        self.log(metrics)
+
+        run_dir = self._get_output_dir(trial)
+        checkpoints_sorted = self._sorted_checkpoints(use_mtime=False, output_dir=run_dir)
+
+        # Delete the last checkpoint when save_total_limit=1 if it's different from the best checkpoint and process allowed to save.
+        if self.args.should_save and self.state.best_model_checkpoint is not None and self.args.save_total_limit == 1:
+            for checkpoint in checkpoints_sorted:
+                if not os.path.samefile(checkpoint, self.state.best_model_checkpoint):
+                    logger.info(f"Deleting older checkpoint [{checkpoint}] due to args.save_total_limit")
+                    shutil.rmtree(checkpoint, ignore_errors=True)
+
+        self.control = self.callback_handler.on_train_end(args, self.state, self.control)
+
+        # Wait for the checkpoint to be uploaded.
+        self._finish_current_push()
+
+        # After training we make sure to retrieve back the original forward pass method
+        # for the embedding layer by removing the forward post hook.
+        if self.neftune_noise_alpha is not None:
+            self._deactivate_neftune(self.model)
+
+        return TrainOutput(self.state.global_step, train_loss, metrics)
+
+    def get_train_dataloader(self) -> DataLoader:
+        """
+        Returns the training [`~torch.utils.data.DataLoader`].
+        Will use no sampler if `train_dataset` does not implement `__len__`, a random sampler (adapted to distributed
+        training if necessary) otherwise.
+        Subclass and override this method if you want to inject some custom behavior.
+        """
+        if self.train_dataset is None:
+            raise ValueError("Trainer: training requires a train_dataset.")
+
+        train_dataset = self.train_dataset
+        data_collator = self.data_collator
+        if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
+            train_dataset = self._remove_unused_columns(train_dataset, description="training")
+        else:
+            data_collator = self._get_collator_with_removed_columns(data_collator, description="training")
+
+        dataloader_params = {
+            "batch_size": self._train_batch_size,
+            "collate_fn": data_collator,
+            "num_workers": self.args.dataloader_num_workers,
+            "pin_memory": False,
+            "persistent_workers": self.args.dataloader_persistent_workers,
+        }
+
+        if not isinstance(train_dataset, torch.utils.data.IterableDataset):
+            dataloader_params["sampler"] = self._get_train_sampler()
+            dataloader_params["drop_last"] = self.args.dataloader_drop_last
+            dataloader_params["worker_init_fn"] = seed_worker
+            dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
+        return DataLoader(train_dataset, **dataloader_params)
+
+    def get_eval_dataloader(self, eval_dataset) -> DataLoader:
+        """
+        Returns the evaluation [`~torch.utils.data.DataLoader`].
+        Subclass and override this method if you want to inject some custom behavior.
+        Args:
+            eval_dataset (`torch.utils.data.Dataset`, *optional*):
+                If provided, will override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns not accepted
+                by the `model.forward()` method are automatically removed. It must implement `__len__`.
+        """
+        if eval_dataset is None and self.eval_dataset is None:
+            raise ValueError("Trainer: evaluation requires an eval_dataset.")
+
+        eval_dataset = eval_dataset if eval_dataset is not None else self.eval_dataset
+        data_collator = self.data_collator
+
+        if is_datasets_available() and isinstance(eval_dataset, datasets.Dataset):
+            eval_dataset = self._remove_unused_columns(eval_dataset, description="evaluation")
+        else:
+            data_collator = self._get_collator_with_removed_columns(data_collator, description="evaluation")
+
+        dataloader_params = {
+            "batch_size": self.args.eval_batch_size,
+            "collate_fn": data_collator,
+            "num_workers": self.args.dataloader_num_workers,
+            "pin_memory": False,
+            "persistent_workers": self.args.dataloader_persistent_workers,
+        }
+
+        if not isinstance(eval_dataset, torch.utils.data.IterableDataset):
+            dataloader_params["sampler"] = self._get_eval_sampler(eval_dataset)
+            dataloader_params["drop_last"] = self.args.dataloader_drop_last
+            dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
+
+        world_size = int(os.environ['WORLD_SIZE'])
+        return DataLoader(eval_dataset, **dataloader_params)

--- a/src/llamafactory/dynamic_sp/utils.py
+++ b/src/llamafactory/dynamic_sp/utils.py
@@ -1,0 +1,64 @@
+from typing import Dict, Optional, Union
+from transformers.tokenization_utils_base import EncodedInput, BatchEncoding, PaddingStrategy
+
+def _nearest_power_of_2(x):
+    x=x-1
+    x|=(x>>1)
+    x|=(x>>2)
+    x|=(x>>4)
+    x|=(x>>8)
+    x|=(x>>16)
+    return x+1
+
+def _power_of_2_pad(
+    self,
+    encoded_inputs: Union[Dict[str, EncodedInput], BatchEncoding],
+    max_length: Optional[int] = None,
+    padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
+    pad_to_multiple_of: Optional[int] = None,
+    padding_side: Optional[bool] = None,
+    return_attention_mask: Optional[bool] = None,
+) -> dict:
+    # Load from model defaults
+    if return_attention_mask is None:
+        return_attention_mask = "attention_mask" in self.model_input_names
+
+    required_input = encoded_inputs[self.model_input_names[0]]
+
+    if padding_strategy == PaddingStrategy.LONGEST:
+        max_length = len(required_input)
+
+    if max_length is not None and pad_to_multiple_of is not None:
+        max_length = _nearest_power_of_2((max_length-1) // pad_to_multiple_of + 1) * pad_to_multiple_of
+
+    needs_to_be_padded = padding_strategy != PaddingStrategy.DO_NOT_PAD and len(required_input) != max_length
+    # Initialize attention mask if not present.
+    if return_attention_mask and "attention_mask" not in encoded_inputs:
+        encoded_inputs["attention_mask"] = [1] * len(required_input)
+    if needs_to_be_padded:
+        difference = max_length - len(required_input)
+        padding_side = padding_side if padding_side is not None else self.padding_side
+
+        if padding_side == "right":
+            if return_attention_mask:
+                encoded_inputs["attention_mask"] = encoded_inputs["attention_mask"] + [0] * difference
+            if "token_type_ids" in encoded_inputs:
+                encoded_inputs["token_type_ids"] = (
+                    encoded_inputs["token_type_ids"] + [self.pad_token_type_id] * difference
+                )
+            if "special_tokens_mask" in encoded_inputs:
+                encoded_inputs["special_tokens_mask"] = encoded_inputs["special_tokens_mask"] + [1] * difference
+            encoded_inputs[self.model_input_names[0]] = required_input + [self.pad_token_id] * difference
+        elif padding_side == "left":
+            if return_attention_mask:
+                encoded_inputs["attention_mask"] = [0] * difference + encoded_inputs["attention_mask"]
+            if "token_type_ids" in encoded_inputs:
+                encoded_inputs["token_type_ids"] = [self.pad_token_type_id] * difference + encoded_inputs[
+                    "token_type_ids"
+                ]
+            if "special_tokens_mask" in encoded_inputs:
+                encoded_inputs["special_tokens_mask"] = [1] * difference + encoded_inputs["special_tokens_mask"]
+            encoded_inputs[self.model_input_names[0]] = [self.pad_token_id] * difference + required_input
+        else:
+            raise ValueError(f"Invalid padding strategy:{padding_side}")
+    return encoded_inputs

--- a/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
+++ b/src/llamafactory/easy_context/dist_flash_attn/async_communication.py
@@ -39,6 +39,8 @@ _fwd_recv_volume = 0
 _bwd_send_volume = 0
 _bwd_recv_volume = 0
 
+_SEQUENCE_PARALLEL_CACHE = {}
+
 def initialize_distributed(sp_size=None):
     if dist.is_initialized():
         if dist.get_rank() == 0:
@@ -63,7 +65,6 @@ def _initialize_sequence_parallel(sequence_parallel_size=None):
     # assert sequence_parallel_size is None, "Multiple sequence parallel group not implemented."
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
-    print(f"sequence_parallel_size is {sequence_parallel_size}, world_size is {world_size}")
 
     if sequence_parallel_size is None or sequence_parallel_size == -1:
         sequence_parallel_size = world_size
@@ -93,14 +94,42 @@ def _initialize_sequence_parallel(sequence_parallel_size=None):
         print("************ Finish sequence pralell group Initialization. ***********")
     # _set_global_memory_buffer()
 
+def reset_sequence_parallel(sequence_parallel_size):
+    assert torch.distributed.is_initialized()
+    global _SEQUENCE_PARALLEL_GROUP
+    global _SEQUENCE_PARALLEL_RANK
+    global _SEQUENCE_PARALLEL_SIZE
+    if sequence_parallel_size in _SEQUENCE_PARALLEL_CACHE:
+        cache = _SEQUENCE_PARALLEL_CACHE[sequence_parallel_size]
+        _SEQUENCE_PARALLEL_GROUP = cache['GROUP']
+        _SEQUENCE_PARALLEL_RANK = cache['RANK']
+        _SEQUENCE_PARALLEL_SIZE = cache['SIZE']
+    else:
+        world_size: int = torch.distributed.get_world_size()
+        num_sequence_parallel_groups: int = world_size // sequence_parallel_size
+        rank = torch.distributed.get_rank()
+
+        # Build the sequence parallel groups.
+        for i in range(num_sequence_parallel_groups):
+            ranks = range(i * sequence_parallel_size, (i + 1) * sequence_parallel_size)
+            group = torch.distributed.new_group(ranks)
+            if rank in ranks:
+                GROUP = group
+                RANK = ranks.index(rank)
+                SIZE = len(ranks)
+                _SEQUENCE_PARALLEL_CACHE[sequence_parallel_size] = {
+                    'GROUP': GROUP,
+                    'RANK': RANK,
+                    'SIZE': SIZE,
+                }
+                _SEQUENCE_PARALLEL_GROUP = GROUP
+                _SEQUENCE_PARALLEL_RANK = RANK
+                _SEQUENCE_PARALLEL_SIZE = SIZE
+    reset_global_memory_buffer()
+
 def maybe_get_set_global_memory_buffer(q, k, v, m, l, o):
     global _PEER_Q, _PEER_K, _PEER_V, _PEER_M, _PEER_L, _PEER_O
     if _PEER_Q is None:
-        try:
-            if get_sequence_parallel_rank() == 0:
-                print("Initializing global memoery buffer.")
-        except:
-            print("Initializing global memoery buffer.")
         _PEER_Q = [torch.empty_like(q) for _ in range(2)]
         _PEER_K = [torch.empty_like(k) for _ in range(2)]
         _PEER_V = [torch.empty_like(v) for _ in range(2)]
@@ -113,11 +142,6 @@ def maybe_get_set_global_memory_buffer(q, k, v, m, l, o):
 def maybe_get_set_global_memory_buffer_bwd(dq, dk, dv, q, L, k, v, o, do):
     global _DELTA_DQ, _DELTA_DK, _DELTA_DV, _DK_DELTA_FROM_PEER, _DV_DELTA_FROM_PEER,_PEER_Q_BWD, _PEER_L, _PEER_K_BWD, _PEER_V_BWD, _PEER_O_BWD, _PEER_DO
     if _DELTA_DQ is None:
-        try:
-            if get_sequence_parallel_rank() == 0:
-                print("Initializing global memoery buffer for backward.")
-        except:
-            print("Initializing global memoery buffer for backward.")
         _DELTA_DQ = [torch.empty_like(dq) for _ in range(2)]
         _DELTA_DK = [torch.empty_like(dk) for _ in range(2)]
         _DELTA_DV = [torch.empty_like(dv) for _ in range(2)]

--- a/src/llamafactory/hparams/finetuning_args.py
+++ b/src/llamafactory/hparams/finetuning_args.py
@@ -334,6 +334,18 @@ class FinetuningArguments(FreezeArguments, LoraArguments, RLHFArguments, GaloreA
         default=0.0,
         metadata={"help": "0 for remain all activation memory in gpu, 1 for offload all activation memory in cpu"}
     )
+    enable_dynamic_sp: bool = field(
+        default=False,
+        metadata={"help": "when enable, disable sp_size and enable seqlen_per_gpu"},
+    )
+    seqlen_per_gpu: int = field(
+        default=4096,
+        metadata={"help": "in dynamic sp mode, seqlen per gpu is fixed and dp/sp size is adjust with the input seqlen"},
+    )
+    total_batch_size: int = field(
+        default=128,
+        metadata={"help": "this param takes effect when enable_dynamic_sp==True, total_batch_size=mini_batch_size*gradient_accumulation*dp_size. in dynamic sp mode, dp_size is not fixed while total_batch_size should be fixed"}
+    )
 
     def __post_init__(self):
         def split_arg(arg):

--- a/src/llamafactory/train/pt/workflow.py
+++ b/src/llamafactory/train/pt/workflow.py
@@ -33,7 +33,7 @@ def run_pt(
     tokenizer = tokenizer_module["tokenizer"]
     dataset = get_dataset(model_args, data_args, training_args, stage="pt", **tokenizer_module)
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train)
-    apply_seq_parallel_monkey_patch(finetuning_args.parallel_mode, "llama", sp_size=finetuning_args.sp_size)
+    apply_seq_parallel_monkey_patch(finetuning_args, "llama")
 
     # data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
     local_rank = int(os.getenv("LOCAL_RANK"))


### PR DESCRIPTION
`动态数据-序列混合并行，结合transformers-4.47` total_batch loss

参数说明：
参数enable_dynamic_sp开启这种训练方式
参数seqlen_per_gpu指定在使用这种训练方式时一个gpu放多长的序列 (**需要保证训练数据的最大长度cutoff_len是这个值的2^n倍**)
参数total_batch_size指定总的batch_size，值相当于原来的mini_batch_size*dp_size*gradient_accumulation

代码逻辑说明：
1. dataloader预加载数据，在加载过程中，数据的长度会被pad到seqlen_per_gpu*2^n（比如设置seqlen_per_gpu=1024, 当前数据长度为1025，则这条数据会被pad到2048长度）
2. 当加载数据的数量达到total_batch_size时，执行动态规划，求解出一个可行解，可行解是指

> sum(dp_i)*mini_batch_size==total_batch_size

，其中dp_i是当前长度的数据data_i在当前数量gpu下会被数据并行的大小, 每个数据的dp_i根据如下方式确定

> dp_i=world_size//sp_i
> sp_i=padded_seqlen//seqlen_per_gpu

举例来说total_batch_size=8, mini_batch_size=1,此时[1]x8是一组可行解，[2]x4是一组可行解，[4]x1+[2]x2 也是一组可行解
3. 在2中，可行解并不一定存在，若不存在，则返回1继续加载数据，若新加载的数据和老数据构成一组可行解，返回这组数据，剩下未被使用的数据仍会保留，存到缓存区
4. 若加载多次依然找不到可行解（这里加载多次手动设置为缓存区中的数据>2*total_batch_size），则退化为求解近似解，近似解是指当前数据可以构成的总batch_size和设置的total_batch_size最接近，即min(|sum(dp_i)*mini_batch_size-total_batch-size|)
5. 在获取一组解（可行解或近似解）后，根据这组解里每份数据的sp_size大小，调整序列并行算法里的并行度

loss一致性测试：
模型：Qwen2.5-0.5B-Instruct
数据集：alpaca_en_demo
原版dist_flash_attn: 
```
{'loss': 1.3509, 'grad_norm': 0.29056357095273216, 'learning_rate': 4.287142857142858e-05, 'epoch': 0.13}
{'loss': 1.6041, 'grad_norm': 0.6758352583510493, 'learning_rate': 3.574285714285714e-05, 'epoch': 0.26}
{'loss': 1.4178, 'grad_norm': 0.47540473210038836, 'learning_rate': 2.861428571428571e-05, 'epoch': 0.38}
{'loss': 1.4567, 'grad_norm': 0.442531953078784, 'learning_rate': 2.1485714285714288e-05, 'epoch': 0.51}
{'loss': 1.3319, 'grad_norm': 0.25284116134805756, 'learning_rate': 1.4357142857142855e-05, 'epoch': 0.64}
{'loss': 1.3275, 'grad_norm': 0.2636095466843321, 'learning_rate': 7.228571428571432e-06, 'epoch': 0.77}
{'loss': 1.3359, 'grad_norm': 0.2198747871165406, 'learning_rate': 9.999999999999998e-08, 'epoch': 0.9}
```
ddpsp-dist_flash_attn
```
{'loss': 1.3513, 'grad_norm': 0.2902865536692281, 'learning_rate': 4.287142857142858e-05, 'epoch': 0.13}
{'loss': 1.6043, 'grad_norm': 0.6736883521828704, 'learning_rate': 3.574285714285714e-05, 'epoch': 0.26}
{'loss': 1.4192, 'grad_norm': 0.48635899328236254, 'learning_rate': 2.861428571428571e-05, 'epoch': 0.38}
{'loss': 1.4569, 'grad_norm': 0.41720137780549826, 'learning_rate': 2.1485714285714288e-05, 'epoch': 0.51}
{'loss': 1.3409, 'grad_norm': 0.3110490036619064, 'learning_rate': 1.4357142857142855e-05, 'epoch': 0.64}
{'loss': 1.3278, 'grad_norm': 0.26012651717806073, 'learning_rate': 7.228571428571432e-06, 'epoch': 0.77}
{'loss': 1.3364, 'grad_norm': 0.22246412410278416, 'learning_rate': 9.999999999999998e-08, 'epoch': 0.9}
```
原版zigzag_ring_attn
```
{'loss': 1.3506, 'grad_norm': 0.28830738798249494, 'learning_rate': 4.287142857142858e-05, 'epoch': 0.13}
{'loss': 1.6108, 'grad_norm': 0.6775776810099262, 'learning_rate': 3.574285714285714e-05, 'epoch': 0.26}
{'loss': 1.4299, 'grad_norm': 0.4772684632719364, 'learning_rate': 2.861428571428571e-05, 'epoch': 0.38}
{'loss': 1.4459, 'grad_norm': 0.36749120354386866, 'learning_rate': 2.1485714285714288e-05, 'epoch': 0.51}
{'loss': 1.328, 'grad_norm': 0.21919710389547797, 'learning_rate': 1.4357142857142855e-05, 'epoch': 0.64}
{'loss': 1.3244, 'grad_norm': 0.24295196947551023, 'learning_rate': 7.228571428571432e-06, 'epoch': 0.77}
{'loss': 1.3358, 'grad_norm': 0.21322147844984582, 'learning_rate': 9.999999999999998e-08, 'epoch': 0.9}
```
ddpsp-zigzag_ring_attn
```
{'loss': 1.3514, 'grad_norm': 0.2880452618088377, 'learning_rate': 4.287142857142858e-05, 'epoch': 0.13}
{'loss': 1.6097, 'grad_norm': 0.674435915062915, 'learning_rate': 3.574285714285714e-05, 'epoch': 0.26}
{'loss': 1.4302, 'grad_norm': 0.4758209744259382, 'learning_rate': 2.861428571428571e-05, 'epoch': 0.38}
{'loss': 1.4461, 'grad_norm': 0.3387676650873746, 'learning_rate': 2.1485714285714288e-05, 'epoch': 0.51}
{'loss': 1.3275, 'grad_norm': 0.21770310544596735, 'learning_rate': 1.4357142857142855e-05, 'epoch': 0.64}
{'loss': 1.324, 'grad_norm': 0.24053623520436868, 'learning_rate': 7.228571428571432e-06, 'epoch': 0.77}
{'loss': 1.3352, 'grad_norm': 0.21540433737435602, 'learning_rate': 9.999999999999998e-08, 'epoch': 0.9}
```
速度测试：
sample_long_sft_32k数据集，使用ddpsp cutoff_len=8*seqlen_per_gpu,相比基线sp_size=8时，速度提升约2.5倍
动态规划时间：total_batch_size=128时，动态时间约0.01秒，相比于一个step的训练时间可以忽略不记